### PR TITLE
[codex] Enhance Ringg developer docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # dependencies
 node_modules
+
+# local brainstorming previews
+.superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Codex Guidance for Ringg API Docs
+
+## Product Documentation Decisions
+
+- Keep docs changes Mintlify-native unless the user explicitly asks for custom components.
+- Do not create standalone public docs/nav pages for `DELETE /agent/{agent_id}` or `PATCH /public/agent/{agent_id}`. If needed, mention these only as contextual notes in the relevant assistant/agent docs.
+- For individual outbound call docs, state that exactly one caller-number option is required: `from_number_id` or `from_number`.
+- Keep workflow contact-list APIs hidden until Workflows is live.
+- Campaign docs should include the standard flow, `POST /campaign/save` plus `POST /campaign/start`.
+- Campaign docs should also include the beta large-campaign flow for 5k+ rows: `POST /campaign/upload-csv`, `GET /campaign/upload-status/{bulk_list_id}`, `POST /campaign/make-call-async`, and `POST /campaign/check-balance/{bulk_list_id}`.

--- a/api-reference/endpoint/calling/initiate-individual-call.mdx
+++ b/api-reference/endpoint/calling/initiate-individual-call.mdx
@@ -11,10 +11,10 @@ Start one outbound call with a configured assistant. Use this endpoint for trans
 | `name` | Recipient name. Ringg also uses this as `callee_name` if you do not provide one in `custom_args_values`. |
 | `mobile_number` | Recipient phone number in E.164 format, for example `+919876543210`. |
 | `agent_id` | Assistant that will handle the conversation. Get it from `GET /agent/all`. |
-| `from_number_id` or `from_number` | Caller ID to use. Pass one of these, or configure a default outbound number on the assistant. |
+| `from_number_id` or `from_number` | Caller ID to use. Exactly one is required. Use `from_number_id` when possible because it is stable across number formatting changes. |
 
 <Warning>
-Provide either `from_number_id` or `from_number`, not both. Phone numbers must include country code.
+Provide either `from_number_id` or `from_number`, not both. Phone numbers passed as `from_number` must include country code.
 </Warning>
 
 ## Minimal request

--- a/api-reference/endpoint/campaign/check-large-campaign-balance.mdx
+++ b/api-reference/endpoint/campaign/check-large-campaign-balance.mdx
@@ -1,0 +1,49 @@
+---
+title: "Check large campaign balance (Beta)"
+description: "Confirm workspace balance before starting beta large-campaign calls."
+openapi: post /campaign/check-balance/{bulk_list_id}
+---
+
+<Warning>
+This endpoint is beta. Use it only after upload processing is complete for a beta large campaign.
+</Warning>
+
+`POST /campaign/check-balance/{bulk_list_id}` checks whether the workspace has enough balance to start calls for the validated rows in a large campaign.
+
+## Endpoint
+
+```text
+POST /campaign/check-balance/{bulk_list_id}
+```
+
+## Path parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `bulk_list_id` | Yes | Large campaign list ID returned by `POST /campaign/upload-csv` |
+
+## Request
+
+```bash
+curl --request POST "https://prod-api.ringg.ai/ca/api/v0/campaign/check-balance/your-bulk-list-id" \
+  --header "X-API-KEY: $RINGG_API_KEY"
+```
+
+## Response guidance
+
+A successful response confirms whether the current balance can cover the validated campaign rows.
+
+```json
+{
+  "bulk_list_id": "123e4567-e89b-12d3-a456-426614174000",
+  "required_credits": 6200,
+  "available_credits": 8500,
+  "sufficient_balance": true
+}
+```
+
+If `sufficient_balance` is `false`, add balance, reduce the campaign size, or contact Ringg support before starting calls.
+
+## Next step
+
+When balance is sufficient, call [Make large campaign calls async](/api-reference/endpoint/campaign/make-large-campaign-calls-async).

--- a/api-reference/endpoint/campaign/get-all-campaigns.mdx
+++ b/api-reference/endpoint/campaign/get-all-campaigns.mdx
@@ -2,13 +2,14 @@
 openapi: get /campaign/all
 ---
 
-Return campaigns in the current workspace. Use this for campaign dashboards, monitoring pages, and post-run reconciliation.
+Return campaigns in the current workspace. Use this for campaign dashboards, monitoring pages, and post-run reconciliation after either the standard flow or the beta large-campaign flow.
 
 ## Query guidance
 
 - Use `limit` and `offset` for pagination.
 - Use `call_count=true` when the UI needs call totals with each campaign.
 - Pair this endpoint with call history filtered by `bulk_list_id` for detailed call-level results.
+- For beta large campaigns, poll [Upload status](/api-reference/endpoint/campaign/get-large-campaign-upload-status) until CSV processing is complete before relying on campaign-level call progress.
 
 ## Typical flow
 
@@ -16,3 +17,11 @@ Return campaigns in the current workspace. Use this for campaign dashboards, mon
 2. Start calls with [Start campaign](/api-reference/endpoint/campaign/start-campaign).
 3. Monitor campaign state here.
 4. Inspect calls through [Get call history](/api-reference/endpoint/history/get-call-history).
+
+## Beta 5,000+ row flow
+
+1. Upload the CSV with [Upload large campaign CSV](/api-reference/endpoint/campaign/upload-large-campaign-csv).
+2. Poll [Get large campaign upload status](/api-reference/endpoint/campaign/get-large-campaign-upload-status).
+3. Confirm balance with [Check large campaign balance](/api-reference/endpoint/campaign/check-large-campaign-balance).
+4. Start calls with [Make large campaign calls async](/api-reference/endpoint/campaign/make-large-campaign-calls-async).
+5. Monitor campaign state here and inspect call rows through call history.

--- a/api-reference/endpoint/campaign/get-large-campaign-upload-status.mdx
+++ b/api-reference/endpoint/campaign/get-large-campaign-upload-status.mdx
@@ -1,0 +1,60 @@
+---
+title: "Get large campaign upload status (Beta)"
+description: "Poll asynchronous CSV processing status for a beta large campaign."
+openapi: get /campaign/upload-status/{bulk_list_id}
+---
+
+<Warning>
+This endpoint is beta. Use it only for lists created with [Upload large campaign CSV](/api-reference/endpoint/campaign/upload-large-campaign-csv).
+</Warning>
+
+`GET /campaign/upload-status/{bulk_list_id}` returns the processing state for a large campaign CSV upload.
+
+## Endpoint
+
+```text
+GET /campaign/upload-status/{bulk_list_id}
+```
+
+## Path parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `bulk_list_id` | Yes | Large campaign list ID returned by `POST /campaign/upload-csv` |
+
+## Request
+
+```bash
+curl --request GET "https://prod-api.ringg.ai/ca/api/v0/campaign/upload-status/your-bulk-list-id" \
+  --header "X-API-KEY: $RINGG_API_KEY"
+```
+
+## Status flow
+
+| Status | Meaning | Next action |
+|--------|---------|-------------|
+| `uploaded` | Ringg accepted the CSV and queued processing | Keep polling |
+| `processing` | Rows are being parsed and validated | Keep polling |
+| `completed` | Processing finished and valid rows are ready | Check balance |
+| `failed` | Processing could not complete | Fix the CSV and upload again |
+
+Some beta workspaces may return equivalent status names such as `ready` for a completed upload. Continue only when the response clearly indicates that CSV processing has finished.
+
+## Response guidance
+
+The response includes the upload state and may include row counts or validation details.
+
+```json
+{
+  "bulk_list_id": "123e4567-e89b-12d3-a456-426614174000",
+  "status": "processing",
+  "total_rows": 6200,
+  "processed_rows": 2800,
+  "successful_rows": 2744,
+  "failed_rows": 56
+}
+```
+
+## Next step
+
+When processing is complete, call [Check large campaign balance](/api-reference/endpoint/campaign/check-large-campaign-balance). If the response shows invalid rows, fix and re-upload the CSV unless your workflow intentionally removes invalid rows.

--- a/api-reference/endpoint/campaign/make-large-campaign-calls-async.mdx
+++ b/api-reference/endpoint/campaign/make-large-campaign-calls-async.mdx
@@ -1,0 +1,58 @@
+---
+title: "Make large campaign calls async (Beta)"
+description: "Start outbound calls for a beta large campaign after upload processing and balance checks."
+openapi: post /campaign/make-call-async
+---
+
+<Warning>
+This endpoint is beta. Use it only after [Get large campaign upload status](/api-reference/endpoint/campaign/get-large-campaign-upload-status) shows processing is complete and [Check large campaign balance](/api-reference/endpoint/campaign/check-large-campaign-balance) confirms sufficient balance.
+</Warning>
+
+`POST /campaign/make-call-async` queues outbound calls for a beta large campaign. Use it instead of `POST /campaign/start` for 5,000+ row campaigns created with `POST /campaign/upload-csv`.
+
+## Endpoint
+
+```text
+POST /campaign/make-call-async
+```
+
+## Request body
+
+Send JSON.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `agent_id` | Yes | Assistant that will handle the campaign calls |
+| `bulk_list_id` | Yes | Large campaign list ID returned by `POST /campaign/upload-csv` |
+| `from_numbers` | Yes | Workspace caller numbers or number IDs to use for outbound calls |
+| `callback_url` | No | URL that should receive post-call events, if configured |
+
+```bash
+curl --request POST "https://prod-api.ringg.ai/ca/api/v0/campaign/make-call-async" \
+  --header "X-API-KEY: $RINGG_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "agent_id": "your-agent-id",
+    "bulk_list_id": "your-bulk-list-id",
+    "from_numbers": ["your-from-number-id"],
+    "callback_url": "https://api.example.com/ringg/campaign-callback"
+  }'
+```
+
+## Response guidance
+
+A successful response means the large campaign was accepted for async scheduling.
+
+```json
+{
+  "bulk_list_id": "123e4567-e89b-12d3-a456-426614174000",
+  "status": "scheduled",
+  "message": "Large campaign calls queued"
+}
+```
+
+Avoid submitting the same `bulk_list_id` more than once unless a previous attempt clearly failed.
+
+## Next step
+
+Monitor progress with [Get all campaigns](/api-reference/endpoint/campaign/get-all-campaigns) and inspect call rows with [Get call history](/api-reference/endpoint/history/get-call-history) filtered by the same `bulk_list_id`.

--- a/api-reference/endpoint/campaign/start-campaign.mdx
+++ b/api-reference/endpoint/campaign/start-campaign.mdx
@@ -2,34 +2,44 @@
 openapi: post /campaign/start
 ---
 
-## Campaign Start Process
+Start a campaign that was created with `POST /campaign/save`. This is the primary start endpoint for the standard campaign flow.
 
-This endpoint starts a previously uploaded campaign by initiating outbound calls to all contacts in the specified campaign list. 
+The endpoint schedules outbound calls for all valid contacts in the uploaded campaign list.
 
 <Warning>
 Before starting a campaign, ensure you have:
-- Uploaded a contact list using the campaign upload endpoint
+- Uploaded a contact list using [Upload campaign contact list](/api-reference/endpoint/campaign/upload-campaign-contact-list)
 - Configured your agent with the appropriate prompts and settings
-- Set up valid from_numbers that are provisioned for your workspace
+- Selected valid `from_numbers` that are provisioned for your workspace
 </Warning>
 
-## Request Parameters
+## Request parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `agent_id` | string | Yes | ID of the agent that will handle all campaign calls |
 | `list_id` | string | Yes | ID of the uploaded campaign contact list |
-| `from_numbers` | array | Yes | Phone numbers to use for outbound calls |
+| `from_numbers` | array | Yes | Workspace caller numbers or number IDs to use for outbound calls |
 
+## Standard flow
 
-## Important Notes
+1. Upload contacts with [Upload campaign contact list](/api-reference/endpoint/campaign/upload-campaign-contact-list).
+2. Save the returned `list_id`.
+3. Start calls with this endpoint.
+4. Monitor progress with [Get all campaigns](/api-reference/endpoint/campaign/get-all-campaigns) and call history filtered by `bulk_list_id`.
+
+## Beta large-campaign start
+
+Do not use this endpoint for the beta 5,000+ row flow. After `POST /campaign/upload-csv`, wait for upload processing to complete, check balance, then start calls with [Make large campaign calls async](/api-reference/endpoint/campaign/make-large-campaign-calls-async).
+
+## Important notes
 
 - **Credits Required**: Ensure your workspace has sufficient credits for all contacts in the campaign
 - **International Calls**: For international numbers, only Twilio from_numbers are supported
 - **Campaign Status**: Once started, the campaign status changes to "scheduled" or "ongoing"
 - **Duplicate Prevention**: Cannot start a campaign that's already in "scheduled" or "ongoing" status
 
-## Error Responses
+## Error responses
 
 - **400**: Invalid agent_id, campaign not found, insufficient credits, or campaign already started
 - **401**: Invalid or missing API key

--- a/api-reference/endpoint/campaign/upload-campaign-contact-list.mdx
+++ b/api-reference/endpoint/campaign/upload-campaign-contact-list.mdx
@@ -2,12 +2,16 @@
 openapi: post /campaign/save
 ---
 
-Upload a CSV file with contact data to create a new campaign. Once uploaded, you can start the campaign to begin making calls.
+Upload a CSV file with contact data to create a campaign. This is the primary upload endpoint for the standard campaign flow: first call `POST /campaign/save`, then start calls with `POST /campaign/start`.
+
+<Info>
+For CSVs with 5,000 or more rows, use the beta large-campaign flow instead: [Upload large campaign CSV](/api-reference/endpoint/campaign/upload-large-campaign-csv), poll upload status, check balance, then start calls asynchronously.
+</Info>
 
 ## Quick start
 
 1. **Prepare your CSV** - Download template from your campaigns tab
-2. **Configure your agent** - Set up prompts and custom variables  
+2. **Configure your agent** - Set up prompts and custom variables
 3. **Upload & configure** - Submit CSV with campaign settings
 4. **Start calling** - Use the returned `list_id` to start your campaign
 
@@ -65,7 +69,7 @@ Map CSV column names to your agent's custom variables:
 ```json
 {
   "callee_name": "Name",
-  "company_name": "Company", 
+  "company_name": "Company",
   "email": "Email",
   "custom_field": "Custom Field 1"
 }
@@ -73,15 +77,14 @@ Map CSV column names to your agent's custom variables:
 
 ### Using Variables
 Reference mapped variables in your agent prompt with `@{{variable_name}}`:
-- `@{{callee_name}}` → "John Doe"
-- `@{{company_name}}` → "XYZ Corp"
+- `@{{callee_name}}` becomes "John Doe"
+- `@{{company_name}}` becomes "XYZ Corp"
 
 ## Call configuration
 
 Control when and how your campaign calls are made:
 
-<details>
-<summary><strong>📞 Call Timing & Limits</strong></summary>
+### Call timing and limits
 
 ```json
 {
@@ -95,10 +98,8 @@ Control when and how your campaign calls are made:
   }
 }
 ```
-</details>
 
-<details>
-<summary><strong>🔄 Retry Settings</strong></summary>
+### Retry settings
 
 ```json
 {
@@ -110,7 +111,6 @@ Control when and how your campaign calls are made:
   }
 }
 ```
-</details>
 
 ## What happens next?
 
@@ -131,6 +131,8 @@ You'll receive a `list_id`. Save it because you need it to start the campaign.
 1. **Save the `list_id`** from the response
 2. **[Start your campaign](/api-reference/endpoint/campaign/start-campaign)** using the `list_id`
 3. **[Monitor progress](/api-reference/endpoint/campaign/get-all-campaigns)** and view results
+
+For 5,000+ row CSVs, the beta flow returns `bulk_list_id` and requires status polling before calls can start.
 
 ### Error Handling
 If upload fails, check:

--- a/api-reference/endpoint/campaign/upload-large-campaign-csv.mdx
+++ b/api-reference/endpoint/campaign/upload-large-campaign-csv.mdx
@@ -1,0 +1,71 @@
+---
+title: "Upload large campaign CSV (Beta)"
+description: "Upload a 5,000+ row campaign CSV for asynchronous processing."
+openapi: post /campaign/upload-csv
+---
+
+<Warning>
+This endpoint is beta. Use it only when large-campaign access is enabled for your workspace. For most campaigns, use [Upload campaign contact list](/api-reference/endpoint/campaign/upload-campaign-contact-list) and then [Start campaign](/api-reference/endpoint/campaign/start-campaign).
+</Warning>
+
+`POST /campaign/upload-csv` starts the beta large-campaign flow. It accepts a large CSV and campaign configuration, then returns a `bulk_list_id` that you use for status polling, balance checking, and async call scheduling.
+
+## Endpoint
+
+```text
+POST /campaign/upload-csv
+```
+
+## When to use
+
+Use this endpoint for CSVs with 5,000 or more rows. It lets Ringg process and validate the upload asynchronously instead of making the initial upload request wait for the full import.
+
+## Request guidance
+
+Send `multipart/form-data`. Use the same CSV template and campaign fields as the standard `POST /campaign/save` flow.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `file` | Yes | CSV file with `Mobile Number` and assistant variable columns |
+| `agent_id` | Yes | Assistant that will handle the campaign calls |
+| `campaign_name` | Yes | Human-readable campaign name |
+| `country_code` | Yes | Dialing prefix, such as `+91` or `+1` |
+| `variables_map` | Yes | JSON string mapping assistant variables to CSV columns |
+| `campaign_start_time` | Yes | Campaign start time in `DD/MM/YYYY, HH:MM` format |
+| `campaign_end_time` | Yes | Campaign end time in `DD/MM/YYYY, HH:MM` format |
+| `call_config` | Yes | JSON string for call window, retry, and call limit settings |
+| `remove_invalid_rows` | No | Set to `true` to skip invalid rows when supported |
+| `transliterate_callee_name` | No | Set to `true` when callee names should be transliterated |
+
+```bash
+curl --request POST "https://prod-api.ringg.ai/ca/api/v0/campaign/upload-csv" \
+  --header "X-API-KEY: $RINGG_API_KEY" \
+  --form 'agent_id="your-agent-id"' \
+  --form 'campaign_name="Renewal reminders - large batch"' \
+  --form 'country_code="+91"' \
+  --form 'variables_map="{\"mobile_number\":\"Mobile Number\",\"callee_name\":\"Name\"}"' \
+  --form 'campaign_start_time="18/10/2026, 09:00"' \
+  --form 'campaign_end_time="18/10/2026, 18:00"' \
+  --form 'call_config="{\"call_time\":{\"call_start_time\":\"09:00\",\"call_end_time\":\"18:00\",\"timezone\":\"Asia/Kolkata\"}}"' \
+  --form "file=@contacts-5000-plus.csv"
+```
+
+<Info>
+Do not set `Content-Type` manually in browser or Node `FormData` clients. Let the client include the multipart boundary.
+</Info>
+
+## Response guidance
+
+Persist the returned `bulk_list_id`. It identifies the uploaded list for every later beta endpoint.
+
+```json
+{
+  "bulk_list_id": "123e4567-e89b-12d3-a456-426614174000",
+  "status": "uploaded",
+  "message": "CSV upload accepted for processing"
+}
+```
+
+## Next step
+
+Poll [Get large campaign upload status](/api-reference/endpoint/campaign/get-large-campaign-upload-status) until the upload is processed. Do not check balance or start calls until processing is complete.

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1317,7 +1317,7 @@
             "og:title": "Initiate Individual Call | Ringg AI"
           }
         },
-        "description": "Starts a new individual outbound call to a specified recipient. The from_number field is required and should be a valid phone number with country code.",
+        "description": "Starts one outbound call to a recipient. Exactly one caller-number option is required: from_number_id or from_number.",
         "operationId": "initiateIndividualCall",
         "parameters": [
           {
@@ -1340,8 +1340,7 @@
                 "required": [
                   "name",
                   "mobile_number",
-                  "agent_id",
-                  "from_number"
+                  "agent_id"
                 ],
                 "properties": {
                   "name": {
@@ -1360,8 +1359,18 @@
                     "example": "830f767a-397e-4b39-82ff-235cd344e2f9"
                   },
                   "from_number": {
-                    "type": "string",
-                    "description": "The phone number to call from (with country code)",
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Caller phone number, or array of caller phone numbers, with country code. Provide either from_number or from_number_id, not both.",
                     "example": "+1987654321"
                   },
                   "custom_args_values": {
@@ -1538,7 +1547,83 @@
                         "timezone": "Asia/Kolkata"
                       }
                     }
+                  },
+                  "from_number_id": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Workspace number ID, or array of workspace number IDs, to use as caller ID. Provide either from_number_id or from_number, not both.",
+                    "example": "from-number-id"
+                  },
+                  "callback_url": {
+                    "type": "string",
+                    "description": "Optional webhook URL for call events for this request.",
+                    "example": "https://api.example.com/ringg/callback"
+                  },
+                  "callback_args": {
+                    "type": "object",
+                    "description": "Optional headers and query params Ringg should include when calling callback_url.",
+                    "properties": {
+                      "headers": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "params": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "version_id": {
+                    "type": "string",
+                    "description": "Optional assistant version ID. Defaults to the active version.",
+                    "example": "387bd8f1-5748-4006-b7fe-6a6455e9d45d"
+                  },
+                  "call_category": {
+                    "type": "string",
+                    "description": "Optional category for internal reporting or workflow grouping.",
+                    "example": "renewal_reminder"
+                  },
+                  "parent_call_id": {
+                    "type": "string",
+                    "description": "Optional parent call ID for follow-up or chained-call flows.",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
                   }
+                },
+                "oneOf": [
+                  {
+                    "required": [
+                      "from_number_id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "from_number"
+                    ]
+                  }
+                ],
+                "example": {
+                  "name": "John Doe",
+                  "mobile_number": "+919876543210",
+                  "agent_id": "830f767a-397e-4b39-82ff-235cd344e2f9",
+                  "from_number_id": "from-number-id",
+                  "custom_args_values": {
+                    "callee_name": "John",
+                    "order_id": "ORD-1042"
+                  },
+                  "callback_url": "https://api.example.com/ringg/callback"
                 }
               }
             }
@@ -4458,13 +4543,33 @@
                   },
                   "primary_language": {
                     "type": "string",
-                    "enum": ["en-US", "en-IN", "hi-IN", "ta-IN", "te-IN", "bn-IN", "mr-IN", "kn-IN", "ka-IN"],
+                    "enum": [
+                      "en-US",
+                      "en-IN",
+                      "hi-IN",
+                      "ta-IN",
+                      "te-IN",
+                      "bn-IN",
+                      "mr-IN",
+                      "kn-IN",
+                      "ka-IN"
+                    ],
                     "description": "(Required) Primary language locale for the agent",
                     "example": "en-IN"
                   },
                   "secondary_language": {
                     "type": "string",
-                    "enum": ["en-US", "en-IN", "hi-IN", "ta-IN", "te-IN", "bn-IN", "mr-IN", "kn-IN", "ka-IN"],
+                    "enum": [
+                      "en-US",
+                      "en-IN",
+                      "hi-IN",
+                      "ta-IN",
+                      "te-IN",
+                      "bn-IN",
+                      "mr-IN",
+                      "kn-IN",
+                      "ka-IN"
+                    ],
                     "description": "(Optional) Secondary language locale for the agent",
                     "example": "hi-IN"
                   },
@@ -4482,7 +4587,11 @@
                   },
                   "agent_type": {
                     "type": "string",
-                    "enum": ["inbound", "outbound", "outbound_inbound"],
+                    "enum": [
+                      "inbound",
+                      "outbound",
+                      "outbound_inbound"
+                    ],
                     "default": "outbound",
                     "description": "(Required) Type of agent. Defaults to outbound.",
                     "example": "outbound"
@@ -4493,7 +4602,12 @@
                       "type": "string"
                     },
                     "description": "(Optional) Custom variables for the agent. For outbound agents, callee_name and mobile_number are always included automatically.",
-                    "example": ["callee_name", "mobile_number", "company", "lead_source"]
+                    "example": [
+                      "callee_name",
+                      "mobile_number",
+                      "company",
+                      "lead_source"
+                    ]
                   }
                 }
               }
@@ -4658,13 +4772,33 @@
                   },
                   "primary_language": {
                     "type": "string",
-                    "enum": ["en-US", "en-IN", "hi-IN", "ta-IN", "te-IN", "bn-IN", "mr-IN", "kn-IN", "ka-IN"],
+                    "enum": [
+                      "en-US",
+                      "en-IN",
+                      "hi-IN",
+                      "ta-IN",
+                      "te-IN",
+                      "bn-IN",
+                      "mr-IN",
+                      "kn-IN",
+                      "ka-IN"
+                    ],
                     "description": "(Optional) Primary language locale for the agent",
                     "example": "en-IN"
                   },
                   "secondary_language": {
                     "type": "string",
-                    "enum": ["en-US", "en-IN", "hi-IN", "ta-IN", "te-IN", "bn-IN", "mr-IN", "kn-IN", "ka-IN"],
+                    "enum": [
+                      "en-US",
+                      "en-IN",
+                      "hi-IN",
+                      "ta-IN",
+                      "te-IN",
+                      "bn-IN",
+                      "mr-IN",
+                      "kn-IN",
+                      "ka-IN"
+                    ],
                     "description": "(Optional) Secondary language locale for the agent",
                     "example": "hi-IN"
                   },
@@ -4682,7 +4816,11 @@
                   },
                   "agent_type": {
                     "type": "string",
-                    "enum": ["inbound", "outbound", "outbound_inbound"],
+                    "enum": [
+                      "inbound",
+                      "outbound",
+                      "outbound_inbound"
+                    ],
                     "description": "(Optional) Type of agent",
                     "example": "outbound"
                   },
@@ -4692,7 +4830,12 @@
                       "type": "string"
                     },
                     "description": "(Optional) Custom variables for the agent. For outbound agents, callee_name and mobile_number cannot be removed.",
-                    "example": ["callee_name", "mobile_number", "company", "lead_source"]
+                    "example": [
+                      "callee_name",
+                      "mobile_number",
+                      "company",
+                      "lead_source"
+                    ]
                   }
                 }
               }
@@ -4774,6 +4917,501 @@
           },
           "404": {
             "description": "Agent not found or does not belong to your workspace."
+          }
+        }
+      }
+    },
+    "/campaign/upload-csv": {
+      "post": {
+        "tags": [
+          "campaign"
+        ],
+        "summary": "Upload Campaign CSV (Beta)",
+        "x-mint": {
+          "metadata": {
+            "og:title": "Upload Campaign CSV Beta | Ringg AI"
+          }
+        },
+        "description": "Beta endpoint for large campaigns of 5k+ rows. Uploads and validates a CSV asynchronously, creating a draft bulk list.",
+        "operationId": "uploadCampaignCsvBeta",
+        "parameters": [
+          {
+            "name": "X-API-KEY",
+            "in": "header",
+            "description": "(Required) Your Ringg AI API key.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "7251cb4b-3373-43a4-844c-b27a1d45e0c9"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "variables_map",
+                  "agent_id",
+                  "country_code",
+                  "campaign_name",
+                  "file"
+                ],
+                "properties": {
+                  "variables_map": {
+                    "type": "string",
+                    "description": "(Required) JSON string mapping assistant variable names to CSV columns.",
+                    "example": "{\"mobile_number\":\"Mobile Number\",\"callee_name\":\"Name\"}"
+                  },
+                  "agent_id": {
+                    "type": "string",
+                    "description": "(Required) Assistant ID used to validate campaign variables.",
+                    "example": "830f767a-397e-4b39-82ff-235cd344e2f9"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "description": "(Required) Phone number country code, for example +91 or +1.",
+                    "example": "+91"
+                  },
+                  "campaign_name": {
+                    "type": "string",
+                    "description": "(Required) Name of the campaign draft.",
+                    "example": "Renewal reminders - large upload"
+                  },
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "(Required) CSV file containing campaign contacts."
+                  },
+                  "remove_invalid_rows": {
+                    "type": "boolean",
+                    "description": "When true, invalid rows are removed instead of failing the upload.",
+                    "default": false,
+                    "example": true
+                  },
+                  "transliterate_callee_name": {
+                    "type": "boolean",
+                    "description": "When true, callee names are transliterated for the assistant language.",
+                    "default": false,
+                    "example": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "CSV upload accepted for asynchronous validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bulk_list_id": {
+                      "type": "string",
+                      "example": "123e4567-e89b-12d3-a456-426614174000"
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "verifying"
+                    },
+                    "campaign_name": {
+                      "type": "string",
+                      "example": "Renewal reminders - large upload"
+                    },
+                    "total_callees": {
+                      "type": "integer",
+                      "example": 5000
+                    },
+                    "invalidated_rows_count": {
+                      "type": "integer",
+                      "example": 12
+                    },
+                    "invalidated_rows_csv_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "https://storage.example.com/invalid-rows.csv"
+                    }
+                  },
+                  "example": {
+                    "bulk_list_id": "123e4567-e89b-12d3-a456-426614174000",
+                    "status": "verifying",
+                    "campaign_name": "Renewal reminders - large upload",
+                    "total_callees": 0,
+                    "invalidated_rows_count": 0,
+                    "invalidated_rows_csv_url": null
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "detail": {
+                      "type": "string",
+                      "example": "Invalid CSV file or variable mapping."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication."
+          }
+        }
+      }
+    },
+    "/campaign/upload-status/{bulk_list_id}": {
+      "get": {
+        "tags": [
+          "campaign"
+        ],
+        "summary": "Get Campaign Upload Status (Beta)",
+        "x-mint": {
+          "metadata": {
+            "og:title": "Get Campaign Upload Status Beta | Ringg AI"
+          }
+        },
+        "description": "Beta endpoint for checking asynchronous CSV validation status before starting a large campaign.",
+        "operationId": "getCampaignUploadStatusBeta",
+        "parameters": [
+          {
+            "name": "X-API-KEY",
+            "in": "header",
+            "description": "(Required) Your Ringg AI API key.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "7251cb4b-3373-43a4-844c-b27a1d45e0c9"
+            }
+          },
+          {
+            "name": "bulk_list_id",
+            "in": "path",
+            "required": true,
+            "description": "Bulk list ID returned by /campaign/upload-csv.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Upload status returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bulk_list_id": {
+                      "type": "string",
+                      "example": "123e4567-e89b-12d3-a456-426614174000"
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "verifying"
+                    },
+                    "campaign_name": {
+                      "type": "string",
+                      "example": "Renewal reminders - large upload"
+                    },
+                    "total_callees": {
+                      "type": "integer",
+                      "example": 5000
+                    },
+                    "invalidated_rows_count": {
+                      "type": "integer",
+                      "example": 12
+                    },
+                    "invalidated_rows_csv_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "https://storage.example.com/invalid-rows.csv"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication."
+          },
+          "404": {
+            "description": "Bulk list not found."
+          }
+        }
+      }
+    },
+    "/campaign/make-call-async": {
+      "post": {
+        "tags": [
+          "campaign"
+        ],
+        "summary": "Start Large Campaign Calls (Beta)",
+        "x-mint": {
+          "metadata": {
+            "og:title": "Start Large Campaign Calls Beta | Ringg AI"
+          }
+        },
+        "description": "Beta endpoint for starting calls from a draft bulk list created by /campaign/upload-csv.",
+        "operationId": "makeCampaignCallAsyncBeta",
+        "parameters": [
+          {
+            "name": "X-API-KEY",
+            "in": "header",
+            "description": "(Required) Your Ringg AI API key.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "7251cb4b-3373-43a4-844c-b27a1d45e0c9"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "bulk_list_id",
+                  "agent_id",
+                  "country_code",
+                  "campaign_start_time",
+                  "campaign_end_time",
+                  "from_numbers",
+                  "call_config"
+                ],
+                "properties": {
+                  "bulk_list_id": {
+                    "type": "string",
+                    "description": "Draft bulk list ID returned by /campaign/upload-csv.",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                  },
+                  "agent_id": {
+                    "type": "string",
+                    "description": "Assistant ID used during upload.",
+                    "example": "830f767a-397e-4b39-82ff-235cd344e2f9"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "description": "Phone number country code.",
+                    "example": "+91"
+                  },
+                  "campaign_start_time": {
+                    "type": "string",
+                    "description": "Campaign start time in DD/MM/YYYY, HH:MM format.",
+                    "example": "18/10/2026, 09:00"
+                  },
+                  "campaign_end_time": {
+                    "type": "string",
+                    "description": "Campaign end time in DD/MM/YYYY, HH:MM format.",
+                    "example": "18/10/2026, 18:00"
+                  },
+                  "from_numbers": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Workspace number IDs to use for outbound calls.",
+                    "example": [
+                      "from-number-id"
+                    ]
+                  },
+                  "call_config": {
+                    "type": "object",
+                    "properties": {
+                      "call_retry_config": {
+                        "type": "object",
+                        "properties": {
+                          "retry_count": {
+                            "type": "integer",
+                            "default": 0,
+                            "example": 1
+                          },
+                          "retry_busy": {
+                            "type": "integer",
+                            "default": 30,
+                            "example": 30
+                          },
+                          "retry_not_picked": {
+                            "type": "integer",
+                            "default": 30,
+                            "example": 30
+                          },
+                          "retry_failed": {
+                            "type": "integer",
+                            "default": 30,
+                            "example": 30
+                          }
+                        }
+                      },
+                      "call_time": {
+                        "type": "object",
+                        "properties": {
+                          "call_start_time": {
+                            "type": "string",
+                            "default": "08:00",
+                            "example": "09:00"
+                          },
+                          "call_end_time": {
+                            "type": "string",
+                            "default": "20:00",
+                            "example": "18:00"
+                          },
+                          "timezone": {
+                            "type": "string",
+                            "default": "Asia/Kolkata",
+                            "example": "Asia/Kolkata"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "concurrency_percentage": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "default": 0,
+                    "example": 25
+                  },
+                  "callback_url": {
+                    "type": "string",
+                    "nullable": true,
+                    "example": "https://api.example.com/ringg/campaign-callback"
+                  },
+                  "email_completion_user_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Large campaign call creation accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "bulk_list_id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  },
+                  "example": {
+                    "message": "Campaign calls scheduled",
+                    "bulk_list_id": "123e4567-e89b-12d3-a456-426614174000",
+                    "status": "scheduled"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "detail": {
+                      "type": "string",
+                      "example": "Bulk list is not ready to start."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication."
+          }
+        }
+      }
+    },
+    "/campaign/check-balance/{bulk_list_id}": {
+      "post": {
+        "tags": [
+          "campaign"
+        ],
+        "summary": "Check Campaign Balance (Beta)",
+        "x-mint": {
+          "metadata": {
+            "og:title": "Check Campaign Balance Beta | Ringg AI"
+          }
+        },
+        "description": "Beta endpoint for re-checking workspace balance after a large campaign entered insufficient_balance status.",
+        "operationId": "checkCampaignBalanceBeta",
+        "parameters": [
+          {
+            "name": "X-API-KEY",
+            "in": "header",
+            "description": "(Required) Your Ringg AI API key.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "7251cb4b-3373-43a4-844c-b27a1d45e0c9"
+            }
+          },
+          {
+            "name": "bulk_list_id",
+            "in": "path",
+            "required": true,
+            "description": "Bulk list ID to re-check.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balance check completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "draft"
+                    },
+                    "bulk_list_id": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing authentication."
+          },
+          "404": {
+            "description": "Bulk list not found."
           }
         }
       }

--- a/api-reference/quick-start/guide.mdx
+++ b/api-reference/quick-start/guide.mdx
@@ -83,7 +83,7 @@ curl --request GET "$RINGG_BASE_URL/workspace/numbers" \
   --header "X-API-KEY: $RINGG_API_KEY"
 ```
 
-Save the selected `from_number_id`. Some assistants may already have default outbound numbers configured, but passing `from_number_id` keeps the first integration explicit.
+Save the selected `from_number_id`. The individual-call API requires exactly one caller-number option: `from_number_id` or `from_number`. Use `from_number_id` when possible because it is stable across number formatting changes.
 
 ## Step 5: Make the call
 

--- a/api-reference/tutorials/setting-up-bulk-calls.mdx
+++ b/api-reference/tutorials/setting-up-bulk-calls.mdx
@@ -1,10 +1,14 @@
 ---
 title: "Setting Up Bulk Calls"
-description: "Upload a campaign CSV, map variables, start bulk outbound calls, and monitor results."
+description: "Upload a campaign CSV, map variables, start outbound calls, and monitor campaign results."
 "og:title": "How to Set Up Bulk Calls in Ringg AI | Step by Step"
 ---
 
-Bulk calls are campaign-driven in Ringg. First upload a CSV to create a campaign list, then start the campaign with one or more caller numbers.
+Bulk calls are campaign-driven in Ringg. For most campaigns, create the campaign with `POST /campaign/save`, then start it with `POST /campaign/start`.
+
+<Info>
+For CSVs with 5,000 or more rows, use the beta large-campaign flow after it is enabled for your workspace. That path uploads and validates the CSV asynchronously before starting calls.
+</Info>
 
 ## Prerequisites
 
@@ -12,6 +16,13 @@ Bulk calls are campaign-driven in Ringg. First upload a CSV to create a campaign
 - An outbound assistant ID
 - One or more workspace number IDs
 - A CSV file with a `Mobile Number` column and any assistant variables
+
+## Choose the campaign flow
+
+| Use case | Flow | Endpoints |
+|----------|------|-----------|
+| Most campaign CSVs | Standard campaign flow | `POST /campaign/save` then `POST /campaign/start` |
+| 5,000+ row CSVs | Beta large-campaign flow | `POST /campaign/upload-csv`, `GET /campaign/upload-status/{bulk_list_id}`, `POST /campaign/check-balance/{bulk_list_id}`, `POST /campaign/make-call-async` |
 
 ## Step 1: Prepare the CSV
 
@@ -23,7 +34,9 @@ Mobile Number,Name,Policy ID,Due Date
 +919876543211,Jane Smith,POL-124,21/10/2026
 ```
 
-## Step 2: Upload the campaign contact list
+## Standard flow
+
+### Step 2: Upload the campaign contact list
 
 `POST /campaign/save` accepts `multipart/form-data`. Do not set `Content-Type` manually in browser or Node `FormData` clients; let the client set the multipart boundary.
 
@@ -69,7 +82,7 @@ console.log(uploadedCampaign.list_id);
 
 Save the returned `list_id`; it is required to start the campaign.
 
-## Step 3: Choose caller numbers
+### Step 3: Choose caller numbers
 
 ```bash
 curl --request GET "https://prod-api.ringg.ai/ca/api/v0/workspace/numbers" \
@@ -78,7 +91,7 @@ curl --request GET "https://prod-api.ringg.ai/ca/api/v0/workspace/numbers" \
 
 Pick one or more number IDs to use as `from_numbers`.
 
-## Step 4: Start the campaign
+### Step 4: Start the campaign
 
 ```bash
 curl --request POST "https://prod-api.ringg.ai/ca/api/v0/campaign/start" \
@@ -92,7 +105,7 @@ curl --request POST "https://prod-api.ringg.ai/ca/api/v0/campaign/start" \
   }'
 ```
 
-## Step 5: Monitor campaign calls
+### Step 5: Monitor campaign calls
 
 Use campaign and history endpoints together:
 
@@ -106,7 +119,7 @@ curl --request GET "https://prod-api.ringg.ai/ca/api/v0/calling/history?bulk_lis
   --header "X-API-KEY: $RINGG_API_KEY"
 ```
 
-## Step 6: Stop calls if needed
+### Step 6: Stop calls if needed
 
 Use termination endpoints for emergency stops or selective campaign cleanup.
 
@@ -119,11 +132,88 @@ curl --request PATCH "https://prod-api.ringg.ai/ca/api/v0/campaign/terminate" \
   }'
 ```
 
+## Beta large-campaign flow
+
+Use this path for CSVs with 5,000 or more rows. It separates upload, validation, balance checking, and call scheduling so long CSV imports do not block one request.
+
+<Warning>
+This flow is beta. Use the standard `POST /campaign/save` plus `POST /campaign/start` flow unless large-campaign beta access is enabled for your workspace.
+</Warning>
+
+### Beta step 1: Upload the CSV
+
+`POST /campaign/upload-csv` accepts the large CSV and campaign metadata. Use the same CSV headers, variable mapping, assistant ID, campaign window, country code, and call configuration you would send to `POST /campaign/save`.
+
+```bash
+curl --request POST "https://prod-api.ringg.ai/ca/api/v0/campaign/upload-csv" \
+  --header "X-API-KEY: $RINGG_API_KEY" \
+  --form 'agent_id="your-agent-id"' \
+  --form 'campaign_name="Renewal reminders - large batch"' \
+  --form 'country_code="+91"' \
+  --form 'variables_map="{\"mobile_number\":\"Mobile Number\",\"callee_name\":\"Name\"}"' \
+  --form 'campaign_start_time="18/10/2026, 09:00"' \
+  --form 'campaign_end_time="18/10/2026, 18:00"' \
+  --form 'call_config="{\"call_time\":{\"call_start_time\":\"09:00\",\"call_end_time\":\"18:00\",\"timezone\":\"Asia/Kolkata\"}}"' \
+  --form "file=@contacts-5000-plus.csv"
+```
+
+Save the returned `bulk_list_id`. Use it for every following beta step.
+
+### Beta step 2: Poll upload status
+
+```bash
+curl --request GET "https://prod-api.ringg.ai/ca/api/v0/campaign/upload-status/your-bulk-list-id" \
+  --header "X-API-KEY: $RINGG_API_KEY"
+```
+
+Wait until processing is complete before checking balance or starting calls. If the status reports invalid rows, fix the CSV or remove invalid rows according to your campaign policy.
+
+### Beta step 3: Check balance
+
+```bash
+curl --request POST "https://prod-api.ringg.ai/ca/api/v0/campaign/check-balance/your-bulk-list-id" \
+  --header "X-API-KEY: $RINGG_API_KEY"
+```
+
+Only continue when the response confirms the workspace has enough balance for the validated rows.
+
+### Beta step 4: Start calls asynchronously
+
+```bash
+curl --request POST "https://prod-api.ringg.ai/ca/api/v0/campaign/make-call-async" \
+  --header "X-API-KEY: $RINGG_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "agent_id": "your-agent-id",
+    "bulk_list_id": "your-bulk-list-id",
+    "from_numbers": ["your-from-number-id"],
+    "callback_url": "https://api.example.com/ringg/campaign-callback"
+  }'
+```
+
+After scheduling, monitor the campaign with `GET /campaign/all` and call history filtered by the same `bulk_list_id`.
+
+<CardGroup cols={2}>
+  <Card title="Upload large campaign CSV" icon="upload" href="/api-reference/endpoint/campaign/upload-large-campaign-csv">
+    Start the beta 5k+ row import.
+  </Card>
+  <Card title="Check upload status" icon="activity" href="/api-reference/endpoint/campaign/get-large-campaign-upload-status">
+    Poll CSV processing before starting calls.
+  </Card>
+  <Card title="Check campaign balance" icon="wallet" href="/api-reference/endpoint/campaign/check-large-campaign-balance">
+    Confirm available balance for the validated contacts.
+  </Card>
+  <Card title="Start async campaign calls" icon="phone-call" href="/api-reference/endpoint/campaign/make-large-campaign-calls-async">
+    Queue the large campaign for outbound calling.
+  </Card>
+</CardGroup>
+
 ## Production checklist
 
 - Start with a small CSV before uploading a large campaign.
 - Set campaign windows in the audience's timezone.
 - Validate CSV headers before upload.
 - Store `list_id` and selected `from_numbers`.
+- Store `bulk_list_id` for beta large campaigns.
 - Subscribe to webhooks for post-call results.
 - Use `remove_invalid_rows=true` when you prefer skipping invalid contacts instead of failing the whole upload.

--- a/docs.json
+++ b/docs.json
@@ -41,7 +41,7 @@
             ]
           },
           {
-            "group": "How-to Guides",
+            "group": "Dashboard Guides",
             "pages": [
               "get-started/guides/create-assistant",
               "get-started/guides/configure-assistant",
@@ -50,8 +50,17 @@
               "get-started/guides/manage-numbers",
               "get-started/guides/view-call-history",
               "get-started/guides/analytics",
-              "get-started/guides/workspace-settings",
-              "get-started/guides/embedding-widget"
+              "get-started/guides/workspace-settings"
+            ]
+          },
+          {
+            "group": "Web Widget",
+            "pages": [
+              "get-started/guides/embedding-widget",
+              "get-started/guides/embedding-widget-configuration",
+              "get-started/guides/embedding-widget-events",
+              "get-started/guides/embedding-widget-chat-widgets",
+              "get-started/guides/embedding-widget-production-qa-security"
             ]
           },
           {
@@ -105,6 +114,16 @@
             ]
           },
           {
+            "group": "Knowledge Base",
+            "pages": [
+              "api-reference/endpoint/kb/create-knowledge-base",
+              "api-reference/endpoint/kb/edit-knowledge-base",
+              "api-reference/endpoint/kb/get-all-knowledge-bases",
+              "api-reference/endpoint/kb/get-knowledge-base-by-id",
+              "api-reference/endpoint/kb/delete-knowledge-base"
+            ]
+          },
+          {
             "group": "Numbers",
             "pages": [
               "api-reference/endpoint/numbers/get-workspace-numbers"
@@ -121,7 +140,11 @@
             "pages": [
               "api-reference/endpoint/campaign/upload-campaign-contact-list",
               "api-reference/endpoint/campaign/start-campaign",
-              "api-reference/endpoint/campaign/get-all-campaigns"
+              "api-reference/endpoint/campaign/get-all-campaigns",
+              "api-reference/endpoint/campaign/upload-large-campaign-csv",
+              "api-reference/endpoint/campaign/get-large-campaign-upload-status",
+              "api-reference/endpoint/campaign/check-large-campaign-balance",
+              "api-reference/endpoint/campaign/make-large-campaign-calls-async"
             ]
           },
           {

--- a/get-started/guides/analytics.mdx
+++ b/get-started/guides/analytics.mdx
@@ -1,93 +1,114 @@
 ---
 title: "Analytics"
 sidebarTitle: "Analytics"
-description: "Monitor call performance, connectivity, and agent efficiency."
+description: "Review call performance, connection rates, costs, and assistant results."
 icon: "chart-spline"
 ---
 
-The **Analytics** page gives you a high-level view of your workspace's call performance over time. Use it to track efficiency, identify issues, and measure assistant outcomes.
+Use **Analytics** to understand how calls are performing across your workspace. It helps business teams answer questions like: Are people picking up? Which assistant is working best? Are calls too short? Are costs aligned with results?
 
 ---
 
-## Accessing Analytics
+## Open Analytics
 
-Click **Analytics** in the left sidebar.
-
-{/* <Frame>
-  <img src="/images/documentation/analytics-page.png" alt="Analytics Page" />
-</Frame> */}
+1. Click **Analytics** in the left sidebar.
+2. Review the default date range.
+3. Use the date picker or filters to narrow the report.
 
 ---
 
-## Setting the Date Range
+## Set the Date Range
 
-By default, the analytics view shows the last 7 days. Click the **date range picker** to change the period, or click the ✕ to reset.
+1. Click the date range picker.
+2. Choose the period you want to review.
+3. Apply the date range.
+4. Click the clear icon to reset when needed.
 
-Click **Filter** to further narrow results by assistant, number, or call status.
+Click **Filter** to narrow results by assistant, number, campaign, status, or other available fields.
 
 ---
 
-## Key Metrics
+## Read the Top Metrics
 
-The top of the page displays a grid of summary metrics:
+The top cards summarize performance for the selected filters.
 
-| Metric | Description |
+| Metric | What It Means |
 |---|---|
-| **Total Calls** | Total number of calls made or received in the selected period |
-| **Calls Connected** | Number of calls where the callee answered |
-| **Connectivity** | Percentage of total calls that were successfully connected (Connected / Total × 100) |
-| **Avg. Duration** | Average call length (shown as X Min Y Sec) |
-| **Total Cost** | Total credit spent on calls in the period (in ₹) |
-| **Registered** | Number of contacts that completed a registration or key action (as tracked by your assistant) |
-| **Voicemail Detected** | Number of calls that hit a voicemail inbox |
-| **Workspace Numbers** | Total active numbers in your workspace |
+| **Total Calls** | All calls in the selected period |
+| **Calls Connected** | Calls where a person answered |
+| **Connectivity** | Connected calls divided by total calls |
+| **Avg. Duration** | Average call length |
+| **Total Cost** | Credits spent in the selected period |
+| **Registered** | Contacts who completed the tracked business action, if configured |
+| **Voicemail Detected** | Calls that reached voicemail |
+| **Workspace Numbers** | Active phone numbers in the workspace |
 
 ---
 
-## Call Status Distribution
+## Review Call Status Distribution
 
-A **donut chart** showing the breakdown of calls by outcome:
+The call status chart shows how calls ended.
 
-- Completed
-- Failed
-- No Answer
-- Voicemail
-- etc.
+Common statuses include:
 
-Hover over segments to see exact counts. This helps you understand what proportion of your calls are reaching real people vs. hitting voicemail or failing.
+- Completed.
+- Failed.
+- No answer.
+- Voicemail.
 
----
-
-## Calls by Day
-
-A **line chart** showing call volume over time. Use the **All** dropdown to filter by a specific assistant.
-
-This chart helps you identify:
-- Peak calling days
-- Drops in call volume (potential campaign issues)
-- The impact of scheduling changes
+Use this chart to spot delivery problems. For example, a high voicemail rate may mean you should change calling hours.
 
 ---
 
-## Assistants in Action
+## Review Calls by Day
 
-A table at the bottom showing per-assistant performance:
+The calls-by-day chart shows volume over time.
 
-| Column | Description |
+Use it to find:
+
+- Peak calling days.
+- Drops in calling volume.
+- Campaign schedule problems.
+- The effect of changing numbers, prompts, or calling windows.
+
+---
+
+## Compare Assistants
+
+The assistant table shows performance by assistant.
+
+| Column | What It Means |
 |---|---|
-| **Agent Name** | The assistant's name |
-| **Call Counts** | Total calls made by this assistant in the period |
-| **Total Connected** | Calls that were answered |
+| **Agent Name** | Assistant name |
+| **Call Counts** | Total calls handled by that assistant |
+| **Total Connected** | Calls answered by a person |
 
-Sort by any column to find your best or worst performing assistants.
+Sort the table to find assistants that need prompt changes, better numbers, or a different audience.
 
 ---
 
-## Using Analytics to Improve Performance
+## What to Try Next
 
-| If you see... | Try... |
+| If You See | Try This |
 |---|---|
-| Low connectivity (< 50%) | Check if your numbers are flagged as spam; try different caller IDs |
-| High voicemail rate | Adjust calling hours to when contacts are more likely to answer |
-| Short avg. duration | Review your assistant's prompt — it may be ending calls too quickly |
-| High total cost, low registered | Improve your prompt's conversion logic; test alternate scripts |
+| Low connectivity | Review caller numbers, calling hours, and audience quality |
+| High voicemail rate | Shift calls to hours when contacts are more likely to answer |
+| Very short calls | Listen to recordings and improve the assistant opening line |
+| High cost with low conversion | Improve targeting, prompt logic, or follow-up rules |
+| One assistant underperforms | Compare its prompt, voice, and knowledge base against better performers |
+
+---
+
+## Developer Handoff
+
+If engineers are building dashboards or investigating analytics, send them:
+
+| Item | Why They Need It |
+|---|---|
+| Date range and timezone | Ensures their report matches the dashboard |
+| Assistant name and `agent_id` | Filters analytics to one assistant |
+| Campaign name and `bulk_list_id` | Filters analytics to one campaign or uploaded list |
+| Status filters | Explains which calls should be included |
+| Business metric definition | Clarifies what counts as registered, qualified, booked, or converted |
+
+For live product dashboards, ask developers to combine analytics APIs with webhook events and call history exports.

--- a/get-started/guides/configure-assistant.mdx
+++ b/get-started/guides/configure-assistant.mdx
@@ -1,237 +1,237 @@
 ---
 title: "Configure an Assistant"
 sidebarTitle: "Configure an Assistant"
-description: "Set up your assistant's prompt, voice, call behaviour, and advanced options."
+description: "Set up an assistant's script, voice, documents, call settings, and developer handoff."
 icon: "sliders-horizontal"
 ---
 
-After creating an assistant, use the configuration page to set up its prompt, voice, call behaviour, and advanced options.
+After creating an assistant, configure what it says, what it can look up, and how calls should behave.
 
-Navigate to **Assistants**, then click on any existing assistant card to open its configuration page.
-
-{/* <Frame>
-  <img src="/images/documentation/assistant-config-overview.png" alt="Assistant Configuration Page" />
-</Frame> */}
+To open the configuration page, click **Assistants** in the left sidebar, then click the assistant you want to edit.
 
 ---
 
-## Configuration Sections
+## Configuration Areas
 
-The left panel organises all settings into three groups:
+The left panel groups settings into three areas.
 
-- **Assistant Settings:** Prompt · Voice · Custom Variables · Knowledge Base
-- **Call Settings:** Call · Chat
-- **Advanced Settings:** Embed · Keyword Boosting · Custom Analysis
+| Area | What You Control |
+|---|---|
+| **Assistant Settings** | Prompt, voice, custom variables, and knowledge base |
+| **Call Settings** | Phone call behavior and webcall chat timing |
+| **Advanced Settings** | Website embed, keyword boosting, and post-call analysis |
 
 ---
 
-## 1. Prompt
+## Prompt
 
-**Assistant Settings → Prompt**
+Click **Assistant Settings** and then **Prompt**.
 
-The Prompt section defines what the assistant says and how it behaves.
+The prompt is the assistant's working script. It has three important parts.
 
-{/* <Frame>
-  <img src="/images/documentation/prompt-settings.png" alt="Prompt Settings" />
-</Frame> */}
+| Part | What to Write |
+|---|---|
+| **First Message** | The exact opening line the assistant says when the call connects |
+| **Objective** | The assistant's role, goal, and business context |
+| **Response Guidelines** | Rules for tone, language, answer length, objections, and handoff behavior |
 
 ### First Message
 
-The exact opening line the assistant speaks when the call connects.
+Keep the first message short and clear.
 
-- Use `@{{variable_name}}` to insert dynamic values (e.g. `@{{callee_name}}`)
-- Type `@` to open the variable picker
-- The **Interruptible** toggle: when ON, the callee can speak before the assistant finishes the opening line
+```text
+Hello, this is Ananya from Aakash Digital. Am I speaking with @{{callee_name}}?
+```
 
-**Example:**
-```
-Hello, नमस्कार! क्या मैं @{{callee_name}} जी से बात कर रही हूं, या उनके parents से?
-```
+Use `@{{variable_name}}` when the greeting should include a value from the calling list, such as the customer's name.
+
+The **Interruptible** setting controls whether the customer can speak before the first message finishes.
 
 ### Objective
 
-A paragraph that tells the assistant who it is, what it's doing, and what it's trying to achieve.
+Write one short paragraph that tells the assistant what to achieve.
 
-**Example:**
-```
-You are Ananya, a warm and knowledgeable academic counsellor calling on behalf of Aakash Digital.
-Your goal is to identify preparation gaps and secure an enrollment confirmation or demo booking.
+```text
+You are Ananya, an academic counselor calling on behalf of Aakash Digital.
+Your goal is to understand the student's exam preparation status and book a demo class if they are interested.
 ```
 
 ### Response Guidelines
 
-Rules the assistant follows throughout the conversation:
+Use bullet points for rules the assistant must follow.
 
-- Tone and persona rules (e.g. "Keep responses 20–45 words per turn")
-- Language switching logic (e.g. "Use formal आप when speaking Hindi")
-- Escalation or handoff conditions
+```text
+- Keep answers under 40 words.
+- Be polite and direct.
+- Switch to Hindi if the customer starts speaking Hindi.
+- If the customer asks for pricing, use the attached knowledge base.
+- If the customer is upset, apologize once and end the call politely.
+```
 
 ---
 
-## 2. Voice
+## Voice
 
-**Assistant Settings → Voice**
+Click **Assistant Settings** and then **Voice**.
 
-{/* <Frame>
-  <img src="/images/documentation/voice-settings.png" alt="Voice Settings" />
-</Frame> */}
-
-| Field | Description |
+| Field | What It Means |
 |---|---|
-| **Primary Language** | The main language for the conversation (e.g. Hindi, English (IN)) |
-| **Secondary Language** | Optional fallback language |
-| **Voice Character** | The voice persona (Tanya, Naina, Raj, Rahul, Anya, etc.) |
+| **Primary Language** | The main language for the call |
+| **Secondary Language** | Optional backup language |
+| **Voice Character** | The voice customers will hear |
 
-Toggle between **Most Used** and **Neutral** to filter available voices.
+Use **Most Used** or **Neutral** to filter voice options. Save the voice, then run a test call before using it in a campaign.
 
 ---
 
-## 3. Custom Variables
+## Custom Variables
 
-**Assistant Settings → Custom Variables**
+Click **Assistant Settings** and then **Custom Variables**.
 
-Custom Variables are dynamic placeholders that get filled at call time — typically from your campaign's calling list CSV.
+Custom variables are placeholders that Ringg AI fills in for each call. They usually come from a campaign CSV or from your backend.
 
-**Examples:**
-- `{{callee_name}}` → "Vikram"
-- `{{mrp}}` → "50000"
-- `{{loan_amount}}` → "₹1,20,000"
+| Variable | Example Value | Where You Might Use It |
+|---|---|---|
+| `callee_name` | `Vikram` | First message |
+| `loan_amount` | `120000` | Collections script |
+| `course_name` | `JEE Advanced` | Admissions or education script |
+
+Use the same spelling in the assistant prompt and in the CSV column name. For example, `@{{callee_name}}` needs a CSV column named `callee_name`.
+
+---
+
+## Knowledge Base
+
+Click **Assistant Settings** and then **Knowledge Base**.
+
+1. Select an existing knowledge base.
+2. Confirm it is trained and ready.
+3. Click **Save**.
+
+Use a knowledge base when the assistant needs to answer questions from approved documents, such as FAQs, pricing, policy rules, product details, or eligibility criteria.
+
+See [Create a Knowledge Base](/get-started/guides/create-knowledge-base) if you need to create one first.
+
+---
+
+## Call Settings
+
+Click **Call Settings** and then **Call**.
+
+| Setting | Plain-English Meaning |
+|---|---|
+| **Maximum Call Duration** | The longest one call can last |
+| **Inactivity Duration** | How long silence can continue before the assistant reacts |
+| **Timezone** | The timezone used for call schedules and reporting |
+| **Noise Filtering** | Helps reduce background noise |
+| **Voicemail Detection** | Detects voicemail instead of a live person |
+| **Leave Voicemail Message** | Lets the assistant leave a voicemail message |
+| **Retry Call** | Tries again when voicemail is detected |
+| **Silence Callee During Introduction** | Prevents interruption during the opening line |
+| **Silence Callee When Assistant is Speaking** | Reduces cross-talk while the assistant speaks |
+| **Enable Background Audio** | Adds background sound for a more natural call |
+| **Enable Graceful Exit Warning** | Warns the customer before ending the call |
 
 <Tip>
-  Use these in your First Message and Objective to personalise every call automatically.
+  For a first launch, keep settings simple. Set a reasonable maximum duration, choose the correct timezone, and test voicemail behavior before calling real contacts.
 </Tip>
 
 ---
 
-## 4. Knowledge Base
+## Chat Settings
 
-**Assistant Settings → Knowledge Base**
+Click **Call Settings** and then **Chat**.
 
-Attach a pre-created Knowledge Base so the assistant can look up information in real time during calls.
+These settings apply to **Webcall** assistants.
 
-<Steps>
-  <Step title="Select Knowledge Base">
-    Click **Knowledge Base** in the left panel.
-  </Step>
-  <Step title="Choose a KB">
-    Select a KB from the list.
-  </Step>
-  <Step title="Save">
-    Save your changes.
-  </Step>
-</Steps>
-
-See [How to Create a Knowledge Base](/get-started/guides/create-knowledge-base) to set one up first.
-
----
-
-## 5. Call Settings
-
-**Call Settings → Call**
-
-{/* <Frame>
-  <img src="/images/documentation/call-settings.png" alt="Call Settings" />
-</Frame> */}
-
-| Setting | Description |
+| Setting | What It Controls |
 |---|---|
-| **Maximum Call Duration** | Max length of a single call (in minutes) before auto-hangup |
-| **Inactivity Duration** | Seconds of silence before the assistant treats the call as inactive |
-| **Timezone** | Timezone used for scheduling and logging calls |
-| **Noise Filtering** | Reduces background noise for clearer audio |
-| **Voicemail Detection** | Automatically detects when the call reaches a voicemail inbox |
-| **Leave Voicemail Message** | When ON, the assistant leaves a pre-recorded message on voicemail |
-| **Retry Call** | When ON, the assistant retries if voicemail is detected |
-| **Silence Callee During Introduction** | Mutes the callee's audio only during the opening message |
-| **Silence Callee When Assistant is Speaking** | Prevents callee audio from interrupting the assistant mid-sentence |
-| **Enable Background Audio** | Plays ambient sound during calls for a more natural feel |
-| **Enable Graceful Exit Warning** | Assistant announces the call is ending before hanging up |
+| **Maximum Call Length** | The total webcall session length |
+| **Idle Timeout Warning** | When the user is warned about inactivity |
+| **Idle Timeout End** | When the webcall ends after inactivity |
 
 ---
 
-## 6. Chat Settings
+## Embed
 
-**Call Settings → Chat**
+Click **Advanced Settings** and then **Embed**.
+
+Use this only for a **Webcall** assistant.
+
+1. Choose the widget theme, size, feedback screen, and branding.
+2. Select the SDK version.
+3. Click **Preview** to check the widget.
+4. Copy the generated code.
+5. Send the code to the website owner or developer.
 
 <Note>
-  Applies to **Webcall** assistants only.
+  Website teams should add the embed code to the website, not to internal documents or email templates.
 </Note>
 
-| Setting | Default | Description |
-|---|---|---|
-| **Maximum Call Length** | 480 seconds | Total allowed session duration |
-| **Idle Timeout Warning** | 20 seconds | Time before warning the user about inactivity |
-| **Idle Timeout End** | 25 seconds | Time before ending the session due to inactivity |
-
 ---
 
-## 7. Embed
+## Keyword Boosting
 
-**Advanced Settings → Embed**
+Click **Advanced Settings** and then **Keyword Boosting**.
 
-Generates an embeddable JavaScript widget for your website.
+Add words the assistant must recognize correctly, such as brand names, course names, product names, city names, acronyms, or plan names.
 
-<Steps>
-  <Step title="Configure Widget">
-    Configure **Theme**, **Widget Size**, **Feedback Screen**, and **Branding** in the right panel.
-  </Step>
-  <Step title="Select SDK Version">
-    Select the SDK version from the dropdown.
-  </Step>
-  <Step title="Preview">
-    Click **Preview** to see a live preview.
-  </Step>
-  <Step title="Copy Code">
-    Copy the **Generated Code** and paste it into your website's HTML.
-  </Step>
-</Steps>
-
-{/* <Frame>
-  <img src="/images/documentation/embed-settings.png" alt="Embed Settings" />
-</Frame> */}
-
----
-
-## 8. Keyword Boosting
-
-**Advanced Settings → Keyword Boosting**
-
-Improve speech recognition accuracy for domain-specific words the assistant frequently hears.
-
-1. Type a keyword in the input field.
+1. Type one keyword.
 2. Click **Add**.
-3. Repeat for all relevant terms (product names, brand names, technical jargon).
+3. Repeat for each important word.
 
 ---
 
-## 9. Custom Analysis
+## Custom Analysis
 
-**Advanced Settings → Custom Analysis**
+Click **Advanced Settings** and then **Custom Analysis**.
 
-Define a post-call analysis prompt that runs automatically after every call.
+Custom analysis extracts structured results after each call. Use it when your team needs consistent reporting fields.
 
-<Steps>
-  <Step title="Enter a Prompt">
-    Describe what information to extract from the call transcript.
-  </Step>
-  <Step title="Define Required Keys">
-    Name the output fields and their data types (e.g. `enrollment_status: String`).
-  </Step>
-  <Step title="Save & Test">
-    Click **Save**, then **Test Analysis** to validate.
-  </Step>
-</Steps>
+Example fields:
 
-**Example Prompt:**
+| Field | Type | Meaning |
+|---|---|---|
+| `interested` | Boolean | Whether the customer showed interest |
+| `preferred_course` | String | Course mentioned by the customer |
+| `objection` | String | Main reason the customer did not agree |
+
+Example prompt:
+
+```text
+From the transcript, extract whether the customer agreed to a demo booking, the preferred course, and the main objection if they declined.
 ```
-From the call transcript, extract:
-- Whether the student agreed to a demo booking
-- The student's preferred course
-- Any objections raised
-```
+
+Click **Save**, then **Test Analysis** before launch.
 
 ---
 
-## Running a Test Call
+## Run a Test Call
 
-At any point, click **Test call** (top-right) to make a live call to a real phone number and verify the assistant behaves as expected.
+Click **Test call** in the top-right corner.
+
+Use a real phone number owned by your team. Check that:
+
+- The first message sounds right.
+- Variables such as customer name are filled correctly.
+- The assistant follows the objective.
+- The voice and language are appropriate.
+- The call ends politely.
+- The transcript and analysis are useful.
+
+---
+
+## Developer Handoff
+
+Send this information to the engineer or website owner before launch:
+
+| Item | Why It Matters |
+|---|---|
+| `agent_id` | Required for API calls, campaigns, webhooks, and webcall setup |
+| Custom variable names | Must match CSV columns or backend payload fields |
+| Knowledge base name or ID | Helps confirm the right documents are attached |
+| Embed code | Needed only for webcall website setup |
+| Webhook events needed | Examples: call status, recording, transcript, custom analysis, all processing completed |
+| Test call results | Gives the developer a real call to verify history, webhooks, and reporting |
+
+For production integrations, ask the developer to configure webhooks after the assistant is approved. See [Webhook setup](/webhooks/initial-setup).

--- a/get-started/guides/create-assistant.mdx
+++ b/get-started/guides/create-assistant.mdx
@@ -1,128 +1,138 @@
 ---
 title: "Create an Assistant"
 sidebarTitle: "Create an Assistant"
-description: "Step-by-step guide to creating a new AI voice assistant in Ringg AI."
+description: "Create a Ringg AI voice assistant from the dashboard."
 icon: "plus"
 ---
 
-This guide walks you through creating a new AI voice assistant in Ringg AI from scratch.
+An assistant is the voice agent that speaks to your customers. Create one first, then connect it to a number, campaign, web widget, or API integration.
 
 ---
 
-## Step 1 — Open the Create Assistant Modal
+## Before You Start
 
-1. Go to **Assistants** in the left sidebar.
-2. Click **+ Create Assistant** in the top-right corner.
+Decide these items before creating the assistant:
 
-{/* <Frame>
-  <img src="/images/documentation/assistants-page.png" alt="Assistants Page with Create Button" />
-</Frame> */}
-
-The **Create Assistant** modal will open.
-
----
-
-## Step 2 — Choose a Call Type
-
-At the top of the modal, select the call direction for your assistant:
-
-| Tab | Description |
+| Decision | What to Prepare |
 |---|---|
-| **Outbound** | Assistant dials the contact (campaigns, follow-ups) |
-| **Inbound** | Assistant picks up calls made to your number |
-| **Webcall** | Assistant handles calls from a web widget on your site |
-
-{/* <Frame>
-  <img src="/images/documentation/create-assistant-modal.png" alt="Create Assistant Modal - Call Type Tabs" />
-</Frame> */}
+| Call direction | Outbound, inbound, or webcall |
+| Use case | Reminder, lead qualification, collections, support, onboarding, or another clear goal |
+| Language | Primary language and optional backup language |
+| Voice | The voice style you want customers to hear |
+| Handoff owner | The person who will configure API calls, webhooks, or website embeds if needed |
 
 ---
 
-## Step 3 — Select a Template or Start from Scratch
+## Step 1 - Open Assistants
 
-<Tabs>
-  <Tab title="Use an Industry Template">
-    In the left panel, choose from:
-    - Logistics
-    - Healthcare
-    - Financial
-    - Education
-    - HR & Recruitment
-    - eCommerce
+1. Log in to the Ringg AI dashboard.
+2. Click **Assistants** in the left sidebar.
+3. Click **+ Create Assistant**.
 
-    Templates pre-fill your assistant's prompt with industry-appropriate language and structure.
-  </Tab>
-  <Tab title="Start from Scratch">
-    Click **Blank Template** (top of the left panel), then choose your orchestration type from the right panel:
-
-    | Option | Description |
-    |---|---|
-    | **Single Prompt** | One prompt drives the entire conversation — ideal for simple flows |
-    | **Multi Prompt** | Multiple connected prompt nodes — ideal for branching conversations |
-  </Tab>
-</Tabs>
+The create assistant window opens.
 
 ---
 
-## Step 4 — Fill in Agent Basics
+## Step 2 - Choose the Call Type
 
-After selecting your template and orchestration type, you'll be taken to the assistant setup form.
+Choose how people will reach the assistant.
 
-Fill in:
-
-1. **Agent Name** *(required)* — A descriptive name for your assistant (e.g. "Loan Collection Agent – Hindi")
-2. **Primary Language** *(required)* — The main language the assistant will speak (e.g. English (IN), Hindi)
-3. **Secondary Language** *(optional)* — A fallback language if the caller switches (e.g. English if primary is Hindi)
-
-{/* <Frame>
-  <img src="/images/documentation/agent-basics-form.png" alt="Agent Basics Form" />
-</Frame> */}
+| Call Type | Use It When |
+|---|---|
+| **Outbound** | Ringg AI should call customers, leads, students, borrowers, or applicants |
+| **Inbound** | Customers should call one of your Ringg AI numbers |
+| **Webcall** | Visitors should start a voice call from your website |
 
 <Tip>
-  Name your assistants descriptively so they're easy to find later — include the use case and language (e.g. "Aakash – Outbound – Hindi/English").
+  Choose **Outbound** for campaigns. Choose **Webcall** only if your website team will add the Ringg AI widget.
 </Tip>
 
 ---
 
-## Step 5 — Choose a Voice
+## Step 3 - Choose a Template
 
-In the **Set up voice** section, pick the voice character your assistant will use:
+Pick the fastest starting point:
 
-1. Toggle between **Most Used** and **Neutral** to filter voices by category.
-2. Click a voice card (e.g. Tanya, Naina, Raj, Rahul, Anya) to select it.
-3. Click **See more** to browse all available voices.
+| Option | Best For |
+|---|---|
+| **Industry template** | You want a ready-made starting script for logistics, healthcare, finance, education, HR, or ecommerce |
+| **Blank template** | You want to write the conversation from scratch |
 
-{/* <Frame>
-  <img src="/images/documentation/voice-selection.png" alt="Voice Selection" />
-</Frame> */}
+If you choose **Blank template**, select the conversation style:
+
+| Style | Best For |
+|---|---|
+| **Single Prompt** | Simple calls that follow one script |
+| **Multi Prompt** | Branching calls where the next step depends on the customer's answer |
+
+---
+
+## Step 4 - Fill in the Basics
+
+Enter the required setup fields.
+
+| Field | What to Enter |
+|---|---|
+| **Agent Name** | A clear name such as `Loan Collection - Hindi` or `Admissions Follow-up - English` |
+| **Primary Language** | The main language the assistant should speak |
+| **Secondary Language** | Optional backup language if callers switch languages |
+
+<Tip>
+  Use names your team can recognize later. Include the use case, call direction, and language when possible.
+</Tip>
+
+---
+
+## Step 5 - Choose a Voice
+
+1. In **Set up voice**, browse the available voices.
+2. Use **Most Used** or **Neutral** to filter the list.
+3. Click a voice card to select it.
+4. Click **See more** if you want more options.
 
 <Note>
-  Each voice has a distinct tone and personality. Test a few with your target audience before finalising.
+  Run test calls with two or three voices before launch. The best voice depends on the audience and use case.
 </Note>
 
 ---
 
-## Step 6 — Click Next
+## Step 6 - Continue to Configuration
 
-Click **Next** to proceed. If any required fields are missing, the form will highlight them in red with a validation message.
+Click **Next**.
+
+If a required field is missing, Ringg AI highlights it. Fill in the missing value and click **Next** again.
 
 ---
 
-## What's Next?
+## Developer Handoff
 
-After creating your assistant, you'll be taken to the assistant configuration page where you can:
+If engineers will trigger calls, embed a widget, or receive call results, give them:
+
+| Item | Why They Need It |
+|---|---|
+| Assistant name | Helps them confirm they are using the right assistant |
+| `agent_id` | Required for API calls, campaigns, and webhook subscriptions |
+| Call type | Tells them whether to build outbound calls, inbound routing, or a webcall embed |
+| Custom variables you plan to use | Helps them send the right customer fields, such as `callee_name` or `loan_amount` |
+| Webhook requirement | Tell them whether your team needs transcripts, recordings, analysis results, or status updates in another system |
+
+If you do not see the `agent_id` in the dashboard, ask the developer to retrieve it from the assistant API using the assistant name.
+
+---
+
+## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Write Your Prompt" icon="pen" href="/get-started/guides/configure-assistant#1-prompt">
-    Set up first message, objective, and response guidelines
+  <Card title="Configure the Assistant" icon="sliders-horizontal" href="/get-started/guides/configure-assistant">
+    Write the prompt, attach documents, and set call behavior.
   </Card>
-  <Card title="Attach a Knowledge Base" icon="folder-git-2" href="/get-started/guides/configure-assistant#4-knowledge-base">
-    Connect reference documents for live call lookups
+  <Card title="Create a Knowledge Base" icon="folder-git-2" href="/get-started/guides/create-knowledge-base">
+    Add documents the assistant can use during calls.
   </Card>
-  <Card title="Configure Call Settings" icon="settings" href="/get-started/guides/configure-assistant#5-call-settings">
-    Set duration, voicemail detection, noise filtering, and more
+  <Card title="Manage Numbers" icon="hash" href="/get-started/guides/manage-numbers">
+    Choose the numbers your assistant or campaigns will use.
   </Card>
-  <Card title="Run a Test Call" icon="phone-call" href="/get-started/guides/configure-assistant#running-a-test-call">
-    Verify your assistant works before going live
+  <Card title="Create a Campaign" icon="notebook-tabs" href="/get-started/guides/create-campaign">
+    Call many contacts with this assistant.
   </Card>
 </CardGroup>

--- a/get-started/guides/create-campaign.mdx
+++ b/get-started/guides/create-campaign.mdx
@@ -1,124 +1,137 @@
 ---
 title: "Create a Campaign"
 sidebarTitle: "Create a Campaign"
-description: "Run bulk outbound calls using an assistant and a contact list."
+description: "Run outbound calls to a contact list from the Ringg AI dashboard."
 icon: "notebook-tabs"
 ---
 
-A Campaign lets you run bulk outbound calls using an assistant and a contact list. Follow these steps to set one up.
+A campaign calls many contacts using one assistant, one or more caller numbers, and a CSV calling list.
 
 ---
 
-## Prerequisites
+## Before You Start
 
-Before creating a campaign, make sure you have:
+Make sure you have:
 
-<Check>An assistant created and configured (see [Create an Assistant](/get-started/guides/create-assistant))</Check>
-<Check>At least one number in your workspace (see [Manage Numbers](/get-started/guides/manage-numbers))</Check>
-<Check>A calling list CSV ready (with phone numbers and any custom variables)</Check>
+<Check>An outbound assistant that has been tested</Check>
+<Check>At least one phone number in your workspace</Check>
+<Check>A CSV file with phone numbers and any fields used by the assistant</Check>
+<Check>Enough call credits for the campaign</Check>
 
 ---
 
-## Step 1 — Open the Campaigns Page
+## Step 1 - Open Campaigns
 
 1. Click **Campaigns** in the left sidebar.
-2. Click **+ Create Campaign** in the top-right corner.
-
-{/* <Frame>
-  <img src="/images/documentation/campaigns-page.png" alt="Campaigns Page" />
-</Frame> */}
+2. Click **+ Create Campaign**.
 
 ---
 
-## Step 2 — Fill in Campaign Settings
+## Step 2 - Fill in Campaign Settings
 
-You'll land on the **Campaign Settings** tab.
+On the **Campaign Settings** tab, fill in:
 
-{/* <Frame>
-  <img src="/images/documentation/campaign-settings-form.png" alt="Campaign Settings Form" />
-</Frame> */}
+| Field | What to Choose |
+|---|---|
+| **Campaign Name** | A clear name such as `March Admissions Follow-up` |
+| **Assistant** | The assistant that should make the calls |
+| **Numbers** | One or more caller numbers |
+| **Campaign Start Date/Time** | When calling should begin |
+| **Campaign End Date/Time** | When calling must stop |
+| **Timezone** | The timezone for the schedule |
+| **Email Notifications** | People who should receive updates |
 
-Fill in the following fields:
-
-| Field | Required | Description |
-|---|---|---|
-| **Campaign Name** | Yes | A clear, descriptive name (e.g. `Aakash ANTHE Follow-up – March 2026`) |
-| **Assistant** | Yes | The assistant that will make the calls |
-| **Numbers** | Yes | One or more numbers to use as caller ID. Multiple numbers distribute load |
-| **Campaign Start Date/Time** | Yes | When the campaign should begin dialling |
-| **Campaign End Date/Time** | Yes | Hard stop time. Uncalled contacts after this time will not be dialled |
-| **Timezone** | Yes | Timezone for your start/end times (e.g. `(UTC+5:30) IST`) |
-| **Email Notifications** | No | Workspace members who should receive email updates |
+<Tip>
+  Use a campaign name that includes the audience, month, and purpose. This makes history and analytics easier to find later.
+</Tip>
 
 ---
 
-## Step 3 — Click Next
+## Step 3 - Upload the Calling List
 
-Click **Next** to move to the **Calling List** tab.
+Click **Next** to open the **Calling List** tab.
 
----
+Upload a CSV file with one row per contact. Include:
 
-## Step 4 — Upload Your Calling List
+- A phone number column.
+- One column for each custom variable used in the assistant prompt.
+- Clear column names with no extra spaces.
 
-On the **Calling List** tab:
-
-1. Upload a CSV file containing your contacts.
-2. The CSV must have a column for the contact's phone number.
-3. Include additional columns for any **Custom Variables** used in your assistant's prompt (e.g. `callee_name`, `mrp`, `loan_amount`).
-
-**Example CSV format:**
+Example:
 
 ```csv
-phone_number,callee_name,mrp
-+919994008915,Sarath,50000
-+919731553396,Vikram,35000
-+917404156687,Sahil,75000
+phone_number,callee_name,course_name
++919994008915,Sarath,JEE Advanced
++919731553396,Vikram,NEET
++917404156687,Sahil,Class 10 Foundation
 ```
 
----
-
-## Step 5 — Launch the Campaign
-
-Review your settings, click **Save CSV** and **Make Call** to activate it.
-
-- If the start time is in the future, the campaign will be in **Scheduled** state.
-- If the start time is now or in the past, it will immediately begin dialling in **Ongoing** state.
+If the assistant prompt uses `@{{callee_name}}`, the CSV must include a `callee_name` column.
 
 ---
 
-## Managing a Running Campaign
+## Step 4 - Save and Start
 
-From the Campaigns list page, use the **Actions** column to:
+1. Review the campaign settings.
+2. Click **Save CSV**.
+3. Click **Make Call** to activate the campaign.
 
-- View call **History** for this campaign
-- **Terminate** a running campaign
-- View call **Analytics** for this campaign
+What happens next depends on the schedule:
+
+| Schedule | Campaign State |
+|---|---|
+| Start time is in the future | **Scheduled** |
+| Start time is now or already passed | **Ongoing** |
 
 ---
 
-## Setting Campaign Concurrency
+## Monitor a Campaign
 
-If multiple campaigns are running simultaneously, you can control how many concurrent calls each gets:
+From the **Campaigns** page, use the **Actions** column to:
 
-<Steps>
-  <Step title="Open Concurrency Settings">
-    Click **Manage Concurrency** on the Campaigns page.
-  </Step>
-  <Step title="Set Workspace Split">
-    On the **Workspace Concurrency** tab, set the split between API calls and campaign calls using the sliders.
-  </Step>
-  <Step title="Allocate Per Campaign">
-    On the **Campaigns Concurrency** tab, allocate slots per active campaign.
-  </Step>
-  <Step title="Save">
-    Click **Save**.
-  </Step>
-</Steps>
+- View campaign call history.
+- View campaign analytics.
+- Terminate a running campaign if needed.
 
-{/* <Frame>
-  <img src="/images/documentation/manage-concurrency.png" alt="Manage Concurrency Modal" />
-</Frame> */}
+Use **History** for call-level details and **Analytics** for performance trends.
+
+---
+
+## Set Campaign Concurrency
+
+Concurrency controls how many calls can happen at the same time.
+
+1. Click **Manage Concurrency** on the Campaigns page.
+2. Use **Workspace Concurrency** to split capacity between API calls and campaign calls.
+3. Use **Campaigns Concurrency** to allocate capacity across running campaigns.
+4. Click **Save**.
 
 <Note>
-  If concurrency is not set, call slots are distributed equally across all running campaigns.
+  If you do not set campaign concurrency, Ringg AI distributes available call slots across running campaigns.
 </Note>
+
+---
+
+## Developer Handoff
+
+If engineers are starting campaigns by API or pulling campaign results into another system, send them:
+
+| Item | Why They Need It |
+|---|---|
+| Campaign name | Lets them confirm they are working with the right campaign |
+| `agent_id` | Identifies the assistant that should make the calls |
+| Caller number or `from_number_id` | Identifies which number should dial contacts |
+| CSV column names | Must match assistant custom variables |
+| `bulk_list_id` or list ID | Identifies the uploaded calling list for start, status, history, and analytics |
+| Webhook requirement | Tells them whether to send call results to CRM, sheets, data warehouse, or support tools |
+
+For the standard API flow, developers should save the campaign with `POST /campaign/save`, then start it with `POST /campaign/start`.
+
+For large campaigns with 5,000 or more rows, use the beta large-campaign flow:
+
+1. `POST /campaign/upload-csv`
+2. `GET /campaign/upload-status/{bulk_list_id}`
+3. `POST /campaign/make-call-async`
+4. `POST /campaign/check-balance/{bulk_list_id}`
+
+Ask developers to store the returned `bulk_list_id` because it is needed to check upload status, start calls, filter history, and reconcile results.

--- a/get-started/guides/create-knowledge-base.mdx
+++ b/get-started/guides/create-knowledge-base.mdx
@@ -1,110 +1,107 @@
 ---
 title: "Create a Knowledge Base"
 sidebarTitle: "Create a Knowledge Base"
-description: "Create Deterministic and Non-Deterministic Knowledge Bases for your assistants."
+description: "Upload approved documents that assistants can use during calls."
 icon: "folder-git-2"
 ---
 
-A Knowledge Base lets your assistant look up information during live calls. This guide walks you through creating both Deterministic and Non-Deterministic KBs.
+A knowledge base lets an assistant answer from approved documents instead of guessing. Use it for FAQs, pricing, policies, eligibility rules, product details, and support scripts.
 
 ---
 
-## Step 1 — Open the Knowledge Base Page
+## Before You Start
+
+Prepare clean source files:
+
+| Requirement | Guidance |
+|---|---|
+| File quality | Use text-based files when possible. Avoid scanned PDFs unless they have searchable text. |
+| File count | Up to 4 files per knowledge base |
+| File size | Up to 512 MB per file |
+| Source owner | Confirm the documents are approved for customer-facing answers |
+| Refresh plan | Decide who will retrain the knowledge base when documents change |
+
+---
+
+## Step 1 - Open Knowledge Base
 
 1. Click **Knowledge Base** in the left sidebar.
-2. Click **Create Knowledge Base** in the top-right corner.
+2. Click **Create Knowledge Base**.
 
-{/* <Frame>
-  <img src="/images/documentation/knowledge-base-page.png" alt="Knowledge Base Page" />
-</Frame> */}
+Choose the knowledge base type.
 
-A dropdown appears with two options:
-
-| Option | Best For |
+| Type | Use It When |
 |---|---|
-| **Deterministic KB** | Structured data — you control the retrieval schema |
-| **Non Deterministic KB** | Unstructured documents — AI determines what to retrieve |
+| **Deterministic KB** | You need structured, predictable answers from fields you define |
+| **Non Deterministic KB** | You have general documents such as FAQs, SOPs, or manuals |
 
 ---
 
-## Creating a Deterministic Knowledge Base
+## Create a Deterministic Knowledge Base
 
-<Steps>
-  <Step title="Choose Deterministic KB">
-    Click **Deterministic KB** from the dropdown.
-  </Step>
-  <Step title="Name Your KB">
-    Enter a **KB Name** to identify it (e.g. "Product Pricing Q1 2026").
-  </Step>
-  <Step title="Upload Files">
-    Drag and drop your files into the upload area, or click to browse.
+Use this for structured information such as pricing tables, policy rules, eligibility fields, product catalogs, or plan comparisons.
 
-    - **Up to 4 files** per Knowledge Base
-    - **Up to 512 MB** per file
-    - Supported formats: PDF, CSV, XLSX, DOCX, and other common document types
-  </Step>
-  <Step title="Edit the Schema">
-    Click **Edit Schema** to define the fields that will be extracted from your documents.
+1. Click **Deterministic KB**.
+2. Enter a clear **KB Name**.
+3. Upload the files.
+4. Click **Edit Schema**.
+5. Add the fields the assistant should retrieve, such as `product_name`, `price`, `policy_code`, or `eligibility_status`.
+6. Choose the data type for each field.
+7. Click **Train Knowledge Base**.
 
-    For each field, set:
-    - **Field name** (e.g. `product_name`, `price`, `policy_code`)
-    - **Data type** (String, Number, Boolean, etc.)
-  </Step>
-  <Step title="Train the Knowledge Base">
-    Click **Train Knowledge Base** to process your uploaded files against the schema.
-
-    Training may take a few minutes depending on file size. Once complete, the KB will appear in your list.
-  </Step>
-</Steps>
-
-{/* <Frame>
-  <img src="/images/documentation/new-kb-form.png" alt="New Knowledge Base Form" />
-</Frame> */}
+Training can take a few minutes. Wait until the knowledge base is ready before attaching it to an assistant.
 
 ---
 
-## Creating a Non-Deterministic Knowledge Base
+## Create a Non Deterministic Knowledge Base
 
-<Steps>
-  <Step title="Choose Non Deterministic KB">
-    Click **Non Deterministic KB** from the dropdown.
-  </Step>
-  <Step title="Name Your KB">
-    Enter a **KB Name**.
-  </Step>
-  <Step title="Upload Files">
-    Upload your files (same limits: 4 files, 512 MB each). These can be FAQs, policy documents, SOPs, product manuals, or any text-heavy document.
-  </Step>
-  <Step title="Train the Knowledge Base">
-    Click **Train Knowledge Base**. The AI will index the content and handle retrieval automatically without a predefined schema.
-  </Step>
-</Steps>
+Use this for less structured documents such as FAQs, help articles, policy documents, SOPs, or product manuals.
+
+1. Click **Non Deterministic KB**.
+2. Enter a clear **KB Name**.
+3. Upload the files.
+4. Click **Train Knowledge Base**.
+
+The assistant will search the uploaded content during calls and use the most relevant information it finds.
 
 ---
 
-## Attaching a KB to an Assistant
+## Attach the Knowledge Base to an Assistant
 
-<Steps>
-  <Step title="Open the Assistant">
-    Go to **Assistants** and open the assistant you want to update.
-  </Step>
-  <Step title="Select Knowledge Base">
-    In the left panel, click **Assistant Settings → Knowledge Base**.
-  </Step>
-  <Step title="Choose and Save">
-    Select your trained Knowledge Base from the list and save.
-  </Step>
-</Steps>
+1. Click **Assistants** in the left sidebar.
+2. Open the assistant that should use the documents.
+3. Click **Assistant Settings** and then **Knowledge Base**.
+4. Select the trained knowledge base.
+5. Click **Save**.
 
-The assistant will now reference this KB during calls when it needs to look up information.
+Run a test call and ask questions that should use the knowledge base. Confirm the assistant answers from the right source.
 
 ---
 
-## Tips for Best Results
+## Tips for Better Answers
 
 <Tip>
-  - Keep documents clean and well-structured (avoid scanned PDFs without OCR)
-  - For Deterministic KBs, ensure column headers in CSV/XLSX match the schema field names
-  - For Non-Deterministic KBs, split very large documents into logical sections for more precise retrieval
-  - Re-train the KB whenever you update the source documents
+  Keep each knowledge base focused on one business topic. A focused pricing KB or FAQ KB is easier to test than one large mixed document set.
 </Tip>
+
+- Use clear document titles and headings.
+- Remove old or conflicting information before upload.
+- For deterministic knowledge bases, make schema field names match your source columns.
+- Retrain after every source document update.
+- Test with real customer questions before launch.
+
+---
+
+## Developer Handoff
+
+If engineers use the knowledge base through APIs or need to verify production setup, send them:
+
+| Item | Why They Need It |
+|---|---|
+| Knowledge base name | Helps them confirm the right document set is attached |
+| Knowledge base type | Explains whether answers are schema-driven or document-search based |
+| Source document owner | Tells them who approves updates |
+| Assistant name and `agent_id` | Lets them confirm the assistant is attached to the correct knowledge base |
+| Test questions | Gives them sample cases for QA and support workflows |
+
+If an integration stores knowledge base IDs, ask the developer to retrieve and store the correct ID after the knowledge base is trained.

--- a/get-started/guides/create-knowledge-base.mdx
+++ b/get-started/guides/create-knowledge-base.mdx
@@ -15,6 +15,8 @@ Prepare clean source files:
 
 | Requirement | Guidance |
 |---|---|
+| Source type | Upload files for document knowledge, use CSV for deterministic row-based data, or add FAQs/URLs when available in your workspace |
+| Supported file types | PDF, DOCX, TXT, CSV, JSON, and other text-readable files. Export spreadsheets to CSV when you need structured deterministic retrieval. |
 | File quality | Use text-based files when possible. Avoid scanned PDFs unless they have searchable text. |
 | File count | Up to 4 files per knowledge base |
 | File size | Up to 512 MB per file |
@@ -43,7 +45,7 @@ Use this for structured information such as pricing tables, policy rules, eligib
 
 1. Click **Deterministic KB**.
 2. Enter a clear **KB Name**.
-3. Upload the files.
+3. Upload a CSV or other structured text file.
 4. Click **Edit Schema**.
 5. Add the fields the assistant should retrieve, such as `product_name`, `price`, `policy_code`, or `eligibility_status`.
 6. Choose the data type for each field.
@@ -59,7 +61,7 @@ Use this for less structured documents such as FAQs, help articles, policy docum
 
 1. Click **Non Deterministic KB**.
 2. Enter a clear **KB Name**.
-3. Upload the files.
+3. Upload source files such as PDFs, DOCX files, TXT files, CSVs, JSON files, or clean text-readable documents.
 4. Click **Train Knowledge Base**.
 
 The assistant will search the uploaded content during calls and use the most relevant information it finds.

--- a/get-started/guides/embedding-widget-chat-widgets.mdx
+++ b/get-started/guides/embedding-widget-chat-widgets.mdx
@@ -1,0 +1,303 @@
+---
+title: "Embedding Widget Chat and Widgets"
+sidebarTitle: "Chat and Widgets"
+icon: "message-square"
+description: "Configure chat mode, chat-only embeds, calendar widgets, form widgets, and chat assistant prompts."
+---
+
+The Ringg widget supports text-based chat alongside voice calls. In chat mode, users type messages while the same assistant can still use configured tools, knowledge base queries, callback scheduling, and form widgets.
+
+## Set up a chat agent
+
+<Tip>
+Create a dedicated assistant for chat by cloning your voice assistant. Chat conversations are usually longer and benefit from prompts that allow structured answers, concise markdown, and clear widget handoffs.
+</Tip>
+
+<Steps>
+  <Step title="Clone or create an assistant">
+    Open the Ringg AI dashboard, go to assistants, and clone an existing voice assistant or create a new Webcall assistant for chat.
+  </Step>
+  <Step title="Tune the prompt for text">
+    Update the assistant prompt for chat-style responses. Include when to answer directly, when to collect details, and when to present widgets.
+  </Step>
+  <Step title="Configure chat-specific tools">
+    Add calendar widgets for callback scheduling, form widgets for data collection, or any API integrations the chat should use.
+  </Step>
+  <Step title="Use the chat assistant ID">
+    Use the cloned assistant's `agentId` in the embed code and set `defaultTab` to `"text"`.
+  </Step>
+</Steps>
+
+## Chat modes
+
+<Tabs>
+  <Tab title="Chat first">
+    ```javascript
+    loadAgent({
+      agentId: "your-chat-agent-id",
+      xApiKey: "your-api-key",
+      defaultTab: "text",
+    });
+    ```
+  </Tab>
+  <Tab title="Chat only">
+    ```javascript
+    loadAgent({
+      agentId: "your-chat-agent-id",
+      xApiKey: "your-api-key",
+      defaultTab: "text",
+      hideTabSelector: true,
+    });
+    ```
+  </Tab>
+  <Tab title="Voice and chat">
+    ```javascript
+    loadAgent({
+      agentId: "your-agent-id",
+      xApiKey: "your-api-key",
+      defaultTab: "audio",
+      hideTabSelector: false,
+    });
+    ```
+  </Tab>
+</Tabs>
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `defaultTab` | `"audio" \| "text"` | `"audio"` | Tab shown when the widget loads. Use `"text"` for chat mode. Supported from v1.0.8+. |
+| `hideTabSelector` | `boolean` | `false` | Hides the audio/text tab switcher for a single-mode experience. Supported from v1.0.8+. |
+| `bypassStartScreen` | `boolean` | `false` | Skips the start screen and begins a call or chat immediately on trigger click. Uses `defaultTab`. |
+
+## How chat mode works
+
+<CardGroup cols={2}>
+  <Card title="Text input and output" icon="keyboard">
+    Users send typed messages. Audio input and output are disabled in text mode.
+  </Card>
+  <Card title="Context compression" icon="archive">
+    Long chat conversations are compressed automatically so the conversation can continue within model context limits.
+  </Card>
+  <Card title="RAG summarization" icon="book-open">
+    Knowledge base query results are summarized in chat mode to reduce token usage and keep answers concise.
+  </Card>
+  <Card title="Same configured tools" icon="wrench">
+    API integrations, knowledge base queries, widgets, and other configured tools work in chat mode.
+  </Card>
+</CardGroup>
+
+## Chat widgets
+
+Chat widgets are interactive UI components the assistant can present during a conversation. They render inside the chat interface so users can schedule callbacks, submit forms, or book appointments without leaving the widget.
+
+<Note>
+Chat widgets work best in text mode. They can also be triggered during voice calls, but visual interaction is most natural in the chat interface.
+</Note>
+
+The widget flow is:
+
+1. The assistant decides a widget is needed and calls the `send_widgets` tool.
+2. The widget renders inside the chat.
+3. The user selects a time slot or submits form data.
+4. The response is sent back to the assistant automatically.
+5. The assistant confirms the action and can trigger an API call if `api_config` is provided.
+
+## Calendar widget
+
+Use the calendar widget for callback scheduling, demo booking, consultations, or follow-up appointments. Past slots are excluded so users see valid options.
+
+<Warning>
+The required `tool_type` value is `calender_widget_tool`. Use that exact spelling in widget metadata.
+</Warning>
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `tool_type` | `string` | Yes | Must be `"calender_widget_tool"`. |
+| `tool_id` | `string` | Yes | Unique identifier for this widget instance. |
+| `slot_duration_days` | `integer` | Yes | Number of days to show slots for, such as `7`. |
+| `slot_interval_minutes` | `integer` | Yes | Minutes between each slot, such as `30`. |
+| `start_time_24_hour_format` | `string` | Yes | Slot start time in `HH:MM` format, such as `"09:00"`. |
+| `end_time_24_hour_format` | `string` | Yes | Slot end time in `HH:MM` format, such as `"17:00"`. |
+| `timezone` | `string` | Yes | IANA timezone, such as `"Asia/Kolkata"`. |
+| `api_config` | `object` | No | Optional API call made when the user selects a slot. |
+
+```json
+{
+  "tool_type": "calender_widget_tool",
+  "tool_id": "callback_scheduler",
+  "slot_duration_days": 7,
+  "slot_interval_minutes": 30,
+  "start_time_24_hour_format": "09:00",
+  "end_time_24_hour_format": "17:00",
+  "timezone": "Asia/Kolkata",
+  "api_config": {
+    "url": "https://your-api.com/schedule-callback",
+    "method": "POST",
+    "headers": {
+      "Authorization": "Bearer your-token",
+      "Content-Type": "application/json"
+    },
+    "body": {}
+  }
+}
+```
+
+When a user schedules a callback, the selected datetime and timezone are sent back to the assistant. If `api_config` is provided, the booking data is forwarded to your API.
+
+## Form widget
+
+Use the form widget for contact details, lead qualification, support tickets, addresses, surveys, or other structured data collection.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `tool_type` | `string` | Yes | Must be `"form_widget_tool"`. |
+| `tool_id` | `string` | Yes | Unique identifier for this widget instance. |
+| `title` | `string` | Yes | Title displayed at the top of the form. |
+| `submit_button_label` | `string` | Yes | Text on the submit button, such as `"Submit"`. |
+| `form_fields` | `array` | Yes | Array of field definitions. |
+| `api_config` | `object` | No | Optional API call made when the form is submitted. |
+
+### Form field definition
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `key` | `string` | Yes | Unique field identifier. |
+| `type` | `string` | Yes | Field type, such as `"text"`, `"email"`, `"select"`, or `"number"`. |
+| `description` | `string` | Yes | Label or placeholder text for the field. |
+| `required` | `boolean` | Yes | Whether the field is mandatory. |
+| `options` | `array` | No | Options list for select fields. |
+
+```json
+{
+  "tool_type": "form_widget_tool",
+  "tool_id": "contact_form",
+  "title": "Contact Information",
+  "submit_button_label": "Submit Details",
+  "form_fields": [
+    {
+      "key": "full_name",
+      "type": "text",
+      "description": "Full Name",
+      "required": true,
+      "options": []
+    },
+    {
+      "key": "email",
+      "type": "email",
+      "description": "Email Address",
+      "required": true,
+      "options": []
+    },
+    {
+      "key": "preferred_plan",
+      "type": "select",
+      "description": "Preferred Plan",
+      "required": false,
+      "options": ["Basic", "Pro", "Enterprise"]
+    }
+  ],
+  "api_config": {
+    "url": "https://your-api.com/contacts",
+    "method": "POST",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {}
+  }
+}
+```
+
+When the user submits the form, the collected data is sent back to the assistant. If `api_config` is provided, the data is also forwarded to your API endpoint.
+
+## Complete chat-only embed
+
+Use the CDN loader from the [quickstart](/get-started/guides/embedding-widget), then load the chat assistant with chat-only mode and optional branding.
+
+```javascript
+loadAgentsCdn("latest", function () {
+  loadAgent({
+    agentId: "your-chat-agent-id",
+    xApiKey: "your-api-key",
+    defaultTab: "text",
+    hideTabSelector: true,
+    title: "Support Chat",
+    description: "Hi! I can help you schedule a callback or answer your questions.",
+    logoUrl: "https://example.com/your-logo.svg",
+    buttons: {
+      modalTrigger: {
+        styles: {
+          backgroundColor: "#4F46E5",
+        },
+        icon: {
+          url: "https://example.com/chat-icon.svg",
+          size: 24,
+        },
+      },
+    },
+    feedbackScreen: {
+      title: "How was your chat?",
+      description: "Your feedback helps us improve!",
+      submitBtnCTA: "Submit",
+    },
+  });
+});
+```
+
+Calendar and form widgets are configured in the assistant metadata through the Ringg AI dashboard. No additional frontend code is needed for the widgets themselves.
+
+## Prompt examples
+
+<Tabs>
+  <Tab title="Callback scheduling">
+    ```text
+    You are a friendly support assistant for [Company Name]. You help users with
+    their questions and can schedule callbacks with our team.
+
+    Guidelines:
+    - Greet the user warmly and ask how you can help.
+    - Answer questions using the knowledge base when available.
+    - If the user wants to speak to a human agent, schedule a call, or book a demo,
+      present the calendar widget so they can pick a convenient time slot.
+    - After the user selects a time slot, confirm the booking with the date, time,
+      and timezone in a clear, human-readable format.
+    - Keep responses concise and conversational. This is a chat, not an email.
+    ```
+  </Tab>
+  <Tab title="Form collection">
+    ```text
+    You are a lead qualification assistant for [Company Name]. Your goal is to
+    understand the user's needs and collect their contact information.
+
+    Guidelines:
+    - Start by understanding what the user is looking for.
+    - Once you have enough context about their needs, present the contact form
+      widget to collect their details: name, email, phone, and preferred plan.
+    - After the form is submitted, thank the user and let them know a team member
+      will follow up shortly.
+    - Do not ask for information that the form will collect. Let the form handle it.
+    ```
+  </Tab>
+  <Tab title="Calendar and form">
+    ```text
+    You are a customer support assistant for [Company Name]. You can help users
+    with questions, collect information, and schedule callbacks.
+
+    Guidelines:
+    - Greet the user and ask how you can help.
+    - For general questions, answer directly using available knowledge.
+    - If the user needs to speak with a human agent or wants a demo, present the
+      calendar widget to schedule a callback.
+    - If the user wants to submit a request, provide feedback, or share details,
+      present the form widget to collect their information.
+    - Always confirm the action after a widget interaction, such as "Your callback
+      is booked for Tuesday at 2:00 PM" or "Thanks, we have received your details."
+    - Keep responses short and friendly.
+    ```
+  </Tab>
+</Tabs>
+
+## Prompt tips
+
+<Check>Be explicit about when to use each widget.</Check>
+<Check>Do not duplicate widget fields in the conversation.</Check>
+<Check>Ask the assistant to confirm bookings and form submissions after the widget returns data.</Check>
+<Check>Keep chat responses shorter and more structured than voice responses.</Check>

--- a/get-started/guides/embedding-widget-configuration.mdx
+++ b/get-started/guides/embedding-widget-configuration.mdx
@@ -1,0 +1,264 @@
+---
+title: "Embedding Widget Configuration"
+sidebarTitle: "Widget Configuration"
+icon: "sliders-horizontal"
+description: "Reference for Ringg AI web widget load options, positioning, styling, variables, and feedback screens."
+---
+
+This page covers the frontend configuration object passed to `loadAgent`. Configure assistant behavior, tools, and widget metadata in the Ringg AI dashboard; use this object for page-level runtime settings.
+
+## CDN loader
+
+The widget script exposes `loadAgent` after the CDN bundle finishes loading.
+
+```html
+<script>
+  function loadAgentsCdn(version, done) {
+    const stylesheet = document.createElement("link");
+    stylesheet.rel = "stylesheet";
+    stylesheet.type = "text/css";
+    stylesheet.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/style.css`;
+
+    const script = document.createElement("script");
+    script.type = "text/javascript";
+    script.onload = done;
+    script.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/dv-agent.es.js`;
+
+    document.head.appendChild(stylesheet);
+    document.head.appendChild(script);
+  }
+</script>
+```
+
+<Tip>
+Use `latest` while exploring in development. For production, pin the tested CDN version and update CSP entries to match your pinned policy.
+</Tip>
+
+## Base configuration
+
+```javascript
+loadAgentsCdn("latest", function () {
+  loadAgent({
+    agentId: "your-agent-id",
+    xApiKey: "your-api-key",
+    variables: {
+      callee_name: "John",
+      account_id: "ACC-42",
+    },
+    defaultTab: "audio",
+    hideTabSelector: false,
+    title: "Talk to our assistant",
+    description: "Ask a question or start a voice call.",
+    buttons: {
+      modalTrigger: {
+        styles: {
+          backgroundColor: "#4F46E5",
+          color: "white",
+          borderRadius: "50%",
+        },
+      },
+      call: {
+        textBeforeCall: "Start Call",
+        textDuringCall: "End Call",
+      },
+    },
+    widgetPosition: {
+      triggerPlacement: "fixed",
+      triggerAlignment: "bottom-right",
+      hideTriggerOnExpand: true,
+      widgetAlignment: "bottom-right",
+    },
+  });
+});
+```
+
+## Core options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `agentId` | `string` | Required | Assistant ID to load in the widget. |
+| `xApiKey` | `string` | Required | Widget API key from the dashboard embed code. |
+| `variables` | `object` | `{}` | Runtime variables available to the assistant. |
+| `defaultTab` | `"audio" \| "text"` | `"audio"` | Tab shown when the widget loads. Use `"text"` for chat mode. Supported from v1.0.8+. |
+| `hideTabSelector` | `boolean` | `false` | Hides the audio/text tab switcher for a single-mode experience. Supported from v1.0.8+. |
+| `bypassStartScreen` | `boolean` | `false` | Skips the start screen and begins a call or chat immediately on trigger click. Uses `defaultTab`. |
+| `title` | `string` | Unset | Heading shown in the widget start screen. |
+| `description` | `string` | Unset | Supporting copy shown in the widget start screen. |
+| `logoUrl` | `string` | Unset | Logo image URL shown in the widget. |
+| `buttons` | `object` | `{}` | Trigger and call button customization. |
+| `widgetPosition` | `object` | Fixed bottom-right | Placement rules for the trigger and expanded widget. |
+| `feedbackScreen` | `object` | Unset | Text for the post-conversation feedback screen. |
+
+## Variables
+
+Use `variables` for page-specific context that the assistant prompt expects.
+
+```javascript
+loadAgent({
+  agentId: "your-agent-id",
+  xApiKey: "your-api-key",
+  variables: {
+    callee_name: "John",
+    account_id: "ACC-42",
+    plan_name: "Enterprise",
+  },
+});
+```
+
+<Warning>
+Variables are sent from the browser. Do not put secrets, internal tokens, or sensitive data in the widget configuration.
+</Warning>
+
+## Mode controls
+
+<Tabs>
+  <Tab title="Voice first">
+    ```javascript
+    loadAgent({
+      agentId: "your-agent-id",
+      xApiKey: "your-api-key",
+      defaultTab: "audio",
+      hideTabSelector: false,
+    });
+    ```
+  </Tab>
+  <Tab title="Chat first">
+    ```javascript
+    loadAgent({
+      agentId: "your-chat-agent-id",
+      xApiKey: "your-api-key",
+      defaultTab: "text",
+      hideTabSelector: false,
+    });
+    ```
+  </Tab>
+  <Tab title="Single mode">
+    ```javascript
+    loadAgent({
+      agentId: "your-chat-agent-id",
+      xApiKey: "your-api-key",
+      defaultTab: "text",
+      hideTabSelector: true,
+    });
+    ```
+  </Tab>
+</Tabs>
+
+For chat setup, see [Chat and Widgets](/get-started/guides/embedding-widget-chat-widgets).
+
+## Widget positioning
+
+Positioning controls are supported from v1.0.19+.
+
+<Tabs>
+  <Tab title="Fixed mode">
+    Fixed mode is the default. The trigger floats over the page and is anchored to the browser viewport.
+
+    ```javascript
+    loadAgent({
+      agentId: "your-agent-id",
+      xApiKey: "your-api-key",
+      widgetPosition: {
+        triggerPlacement: "fixed",
+        triggerAlignment: "bottom-right",
+        hideTriggerOnExpand: true,
+        widgetAlignment: "bottom-right",
+      },
+    });
+    ```
+  </Tab>
+  <Tab title="Absolute mode">
+    Absolute mode embeds the widget inside a page container. The container must exist before `loadAgent` runs and should have an explicit height.
+
+    ```html
+    <div id="ringg_ai_container" style="position: relative; width: 100%; height: 500px;"></div>
+    ```
+
+    ```javascript
+    loadAgent({
+      agentId: "your-agent-id",
+      xApiKey: "your-api-key",
+      widgetPosition: {
+        triggerPlacement: "absolute",
+        triggerAlignment: "center",
+      },
+    });
+    ```
+  </Tab>
+</Tabs>
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `triggerPlacement` | `string` | `"fixed"` | Use `"fixed"` for viewport placement or `"absolute"` for the `ringg_ai_container` container. |
+| `triggerAlignment` | `string` | `"bottom-right"` | Trigger button position. |
+| `hideTriggerOnExpand` | `boolean` | `true` | Hides the trigger button when the widget is open. |
+| `widgetAlignment` | `string` | `"bottom-right"` | Expanded widget position. |
+
+## Trigger button customization
+
+Trigger button customization is supported from v1.0.19+.
+
+```javascript
+loadAgent({
+  agentId: "your-agent-id",
+  xApiKey: "your-api-key",
+  buttons: {
+    modalTrigger: {
+      styles: {
+        backgroundColor: "#4F46E5",
+        color: "white",
+        width: 64,
+        height: 64,
+        borderRadius: "50%",
+      },
+      icon: {
+        url: "https://example.com/my-icon.svg",
+        size: 24,
+      },
+    },
+  },
+});
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `buttons.modalTrigger.styles` | `CSSProperties` | Unset | Button CSS styles, such as `width`, `height`, `backgroundColor`, `color`, and `borderRadius`. |
+| `buttons.modalTrigger.icon.url` | `string` | Ringg phone icon | Custom trigger icon URL. |
+| `buttons.modalTrigger.icon.size` | `number` | `20` | Icon size in pixels. |
+
+## Call button labels
+
+```javascript
+loadAgent({
+  agentId: "your-agent-id",
+  xApiKey: "your-api-key",
+  buttons: {
+    call: {
+      textBeforeCall: "Start Call",
+      textDuringCall: "End Call",
+    },
+  },
+});
+```
+
+## Feedback screen
+
+Use `feedbackScreen` to customize the post-conversation feedback copy.
+
+```javascript
+loadAgent({
+  agentId: "your-agent-id",
+  xApiKey: "your-api-key",
+  feedbackScreen: {
+    title: "How was your chat?",
+    description: "Your feedback helps us improve!",
+    submitBtnCTA: "Submit",
+  },
+});
+```
+
+| Option | Type | Description |
+|---|---|---|
+| `feedbackScreen.title` | `string` | Title shown on the feedback screen. |
+| `feedbackScreen.description` | `string` | Supporting feedback copy. |
+| `feedbackScreen.submitBtnCTA` | `string` | Text for the submit button. |

--- a/get-started/guides/embedding-widget-events.mdx
+++ b/get-started/guides/embedding-widget-events.mdx
@@ -1,0 +1,107 @@
+---
+title: "Embedding Widget Events"
+sidebarTitle: "Widget Events"
+icon: "radio"
+description: "Subscribe to Ringg AI widget browser events for UI state, conversations, and feedback."
+---
+
+The Ringg AI widget dispatches browser `CustomEvent` events on `window`. Use these events to sync your page UI, track analytics, or run post-conversation workflows. Widget events are supported from v1.0.17+.
+
+## Event reference
+
+| Event | Fires when | `event.detail` |
+|---|---|---|
+| `ringg:widget_status` | The widget opens or closes. | `status`: `"maximised"` or `"minimised"`; `mode`: `"audio"` or `"text"`. |
+| `ringg:conversation_status` | A voice or chat conversation starts or ends. | `status`: `"started"` or `"ended"`; `mode`: `"audio"` or `"text"`; `callId`: `string`. |
+| `ringg:feedback_status` | The user submits or skips feedback. | `status`: `"submitted"` or `"skipped"`; `callId`: `string`; optional `rating`: `number`. |
+
+## Basic listeners
+
+```javascript
+window.addEventListener("ringg:widget_status", (event) => {
+  console.log(event.detail);
+  // { status: "maximised", mode: "audio" }
+});
+
+window.addEventListener("ringg:conversation_status", (event) => {
+  console.log(event.detail);
+  // { status: "started", mode: "audio", callId: "abc123" }
+});
+
+window.addEventListener("ringg:feedback_status", (event) => {
+  console.log(event.detail);
+  // { status: "submitted", callId: "abc123", rating: 5 }
+});
+```
+
+## Analytics example
+
+```javascript
+window.addEventListener("ringg:conversation_status", (event) => {
+  const { status, mode, callId } = event.detail;
+
+  if (status === "started") {
+    analytics.track("Ringg Conversation Started", {
+      callId,
+      mode,
+    });
+  }
+
+  if (status === "ended") {
+    analytics.track("Ringg Conversation Ended", {
+      callId,
+      mode,
+    });
+  }
+});
+```
+
+## Page UI example
+
+Use `ringg:widget_status` when your page needs to react to the widget state, such as hiding a competing chat launcher.
+
+```javascript
+const supportLauncher = document.querySelector("[data-support-launcher]");
+
+window.addEventListener("ringg:widget_status", (event) => {
+  const { status } = event.detail;
+
+  if (!supportLauncher) {
+    return;
+  }
+
+  supportLauncher.hidden = status === "maximised";
+});
+```
+
+## React cleanup example
+
+If you attach listeners in a single-page app, remove them when the component unmounts so navigation does not create duplicate handlers.
+
+```javascript
+import { useEffect } from "react";
+
+export function RinggEventBridge() {
+  useEffect(() => {
+    function handleConversationStatus(event) {
+      const { status, mode, callId } = event.detail;
+      console.log({ status, mode, callId });
+    }
+
+    window.addEventListener("ringg:conversation_status", handleConversationStatus);
+
+    return () => {
+      window.removeEventListener("ringg:conversation_status", handleConversationStatus);
+    };
+  }, []);
+
+  return null;
+}
+```
+
+## QA notes
+
+<Check>Open and close the widget once, then confirm one `ringg:widget_status` event per action.</Check>
+<Check>Start and end one voice call, then confirm `ringg:conversation_status` includes a `callId`.</Check>
+<Check>Submit and skip feedback in separate tests if feedback is enabled.</Check>
+<Check>In single-page apps, navigate away and back, then confirm listeners are not duplicated.</Check>

--- a/get-started/guides/embedding-widget-production-qa-security.mdx
+++ b/get-started/guides/embedding-widget-production-qa-security.mdx
@@ -1,0 +1,116 @@
+---
+title: "Embedding Widget Production QA and Security"
+sidebarTitle: "Production QA"
+icon: "shield-check"
+description: "Security and launch checklist for deploying the Ringg AI web widget."
+---
+
+Use this checklist before moving a Ringg AI widget from staging to production. The main risks are public browser credentials, domain allowlisting, CSP, CDN version drift, and browser-specific call behavior.
+
+## Security controls
+
+<Check>Use the dashboard-generated widget key for the web-call assistant, not a broad backend integration key.</Check>
+<Check>Add every allowed staging and production host to the assistant's Whitelist Domains list.</Check>
+<Check>Keep `variables` free of secrets, internal tokens, and sensitive data that should not be visible in browser dev tools.</Check>
+<Check>Pin a tested CDN version in production instead of loading `latest`.</Check>
+<Check>Review analytics and event listeners so user identifiers are handled according to your privacy policy.</Check>
+
+<Warning>
+Anything in the embed snippet can be viewed by a site visitor. Treat `xApiKey`, `variables`, and custom widget metadata as browser-visible configuration.
+</Warning>
+
+## Domain whitelist
+
+Add each domain where the widget is allowed to run in the assistant WebCall settings.
+
+| Environment | Example domain |
+|---|---|
+| Local development | `localhost` if your dashboard setup allows it. |
+| Staging | `staging.example.com` |
+| Production | `www.example.com` |
+
+<Note>
+Whitelist staging separately from production so you can test CDN version pins, CSP changes, and assistant changes before launch.
+</Note>
+
+## CSP setup
+
+If your site uses Content Security Policy, allow the Ringg widget CDN for scripts and styles.
+
+```text
+script-src 'self' https://cdn.jsdelivr.net;
+style-src 'self' https://cdn.jsdelivr.net;
+```
+
+If your policy pins exact asset paths, match the CDN version used by the loader.
+
+```text
+script-src 'self' https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@1.0.19/dist/dv-agent.es.js;
+style-src 'self' https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@1.0.19/dist/style.css;
+```
+
+<Tip>
+Keep the loader version, CSP entries, and release notes for your deployment in sync. A mismatch can make the widget work in staging and fail in production.
+</Tip>
+
+## CDN version pinning
+
+During development:
+
+```javascript
+loadAgentsCdn("latest", function () {
+  loadAgent({
+    agentId: "your-agent-id",
+    xApiKey: "your-api-key",
+  });
+});
+```
+
+For production, replace `latest` with the tested version.
+
+```javascript
+loadAgentsCdn("1.0.19", function () {
+  loadAgent({
+    agentId: "your-agent-id",
+    xApiKey: "your-api-key",
+  });
+});
+```
+
+## Browser QA checklist
+
+<Check>The widget appears in the expected position at desktop, tablet, and mobile widths.</Check>
+<Check>Voice mode requests microphone permission and handles both allow and deny paths.</Check>
+<Check>A test call can start, receive audio, and end cleanly.</Check>
+<Check>Chat mode sends and receives messages if `defaultTab` is `"text"`.</Check>
+<Check>Calendar widgets hide past slots and return the selected date, time, and timezone.</Check>
+<Check>Form widgets validate required fields and submit the expected field keys.</Check>
+<Check>Widget events fire once per action and do not duplicate after client-side navigation.</Check>
+<Check>Console and network panels have no blocked CDN, CSP, or mixed-content errors.</Check>
+
+## Launch checks
+
+<Steps>
+  <Step title="Verify dashboard settings">
+    Confirm the assistant is configured for Webcall, the correct `agentId` is used, and all production domains are whitelisted.
+  </Step>
+  <Step title="Verify the embed snippet">
+    Confirm the deployed page uses the production key, the pinned CDN version, and the expected `defaultTab`, `variables`, and styling options.
+  </Step>
+  <Step title="Verify security policy">
+    Confirm CSP allows the pinned CDN script and stylesheet. If your site has stricter policies, test the deployed production headers directly.
+  </Step>
+  <Step title="Run an end-to-end conversation">
+    Start and end one voice call or chat session, submit feedback if enabled, and confirm any configured analytics or widget event handlers receive the expected payload.
+  </Step>
+</Steps>
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Trigger button does not appear | Confirm the CDN script loaded, CSP is not blocking assets, and `loadAgent` runs after the CDN callback. |
+| Widget appears on staging but not production | Confirm the production domain is in Whitelist Domains and CSP uses the same pinned CDN version. |
+| Voice call cannot start | Confirm microphone permission, browser support, and that the assistant is configured for Webcall. |
+| Chat opens in the wrong mode | Confirm `defaultTab` and `hideTabSelector` in the deployed `loadAgent` config. |
+| Analytics fire twice | Remove duplicate event listeners during single-page app navigation. |

--- a/get-started/guides/embedding-widget.mdx
+++ b/get-started/guides/embedding-widget.mdx
@@ -2,608 +2,135 @@
 title: "Embedding Widget"
 sidebarTitle: "Embedding Widget"
 icon: "globe"
-description: "This guide will walk you through embedding a Ringg AI voice or chat assistant on your website, including widget customization, chat agents, interactive widgets, and tools"
+description: "Embed a Ringg AI voice or chat assistant on your website."
 "og:title": "How to Embed Web Call Widget | Ringg AI Guide"
 ---
 
+Use this quickstart to add a Ringg AI web-call widget to a page. Start with the minimal snippet, verify it in staging, then add branding, chat mode, events, and production controls from the linked reference pages.
+
+<CardGroup cols={2}>
+  <Card title="Configuration Reference" icon="sliders-horizontal" href="/get-started/guides/embedding-widget-configuration">
+    Load options, variables, positioning, trigger styling, and feedback screens.
+  </Card>
+  <Card title="Widget Events" icon="radio" href="/get-started/guides/embedding-widget-events">
+    Browser events for widget state, conversation state, and feedback actions.
+  </Card>
+  <Card title="Chat and Widgets" icon="message-square" href="/get-started/guides/embedding-widget-chat-widgets">
+    Text mode, chat-only embeds, calendar widgets, form widgets, and prompt examples.
+  </Card>
+  <Card title="Production QA and Security" icon="shield-check" href="/get-started/guides/embedding-widget-production-qa-security">
+    Domain whitelisting, CSP, CDN pinning, browser QA, and launch checks.
+  </Card>
+</CardGroup>
 
 ## Prerequisites
 
-Before you begin, make sure you have:
-
-* An active Ringg AI account
-
-* Your API key (X-API-KEY)
-
-* An assistant configured for web calls
-
-* Access to modify your website's HTML
+<Check>An active Ringg AI account.</Check>
+<Check>An assistant configured for Webcall in the Ringg AI dashboard.</Check>
+<Check>The assistant `agentId` and the widget `X-API-KEY` from the generated embed code.</Check>
+<Check>Access to add JavaScript to your website HTML or tag manager.</Check>
+<Check>Each staging and production domain added to the assistant's Whitelist Domains list.</Check>
 
 <Warning>
-The widget snippet runs in the browser and includes `xApiKey`. Only use the embed code generated for a web-call assistant, whitelist the domains where it can run, and avoid using a broad backend integration key in public pages.
+The widget snippet runs in the browser and includes `xApiKey`. Use only the embed code generated for a web-call assistant, whitelist the exact domains where it can run, and do not expose a broad backend integration key in public pages.
 </Warning>
 
-## Execution
-
-**_Step 1: Configure Your Assistant for Web Calls_**
-
-* Open your assistant in the Ringg AI dashboard
-
-* Navigate to the assistant settings
-
-* Configure the WebCall Settings section
-
-* Add your website domain to the Whitelist Domains list
-
-**_Step 2: Get the Embed Code_**
-
-* Open your assistant in the Ringg AI dashboard
-
-* Click the Embed button in the top right corner
-
-* Copy the provided code snippet
-
-For production sites, pin a tested CDN version instead of `latest` after you have verified the widget behavior in staging.
-
-The embed code will look similar to this:
-
-```
-<script>
-	 function loadAgentsCdn(e, t) {
-		 let n = document.createElement("link");
-		 n.rel = "stylesheet", n.type = "text/css", n.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${e}/dist/style.css`;
-		 var a = document.createElement("script");
-		 a.type = "text/javascript", a.readyState ? a.onreadystatechange = function() {
-			 "loaded" !== a.readyState && "complete" !== a.readyState || (a.onreadystatechange = null, t())
-		 } : a.onload = function() {
-			 t()
-		 }, a.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${e}/dist/dv-agent.es.js`, document.getElementsByTagName("head")[0].appendChild(n), document.getElementsByTagName("head")[0].appendChild(a)
-	 }
-</script>
-```
-
-```
-<script>
-	 loadAgentsCdn("latest", function() {
-		 loadAgent({
-			 agentId: "your-agent-id",
-			 xApiKey: "your-api-key",
-			 variables: {},
-			 buttons: {},
-		 });
-	 });
-</script>
-```
-
-**_Step 3: Customize the Embed Code_**
-
-Modify the configuration object to customize the appearance and behavior of the Web Call assistant. Start with a small working config, then add advanced options as needed.
-
-```javascript
-loadAgent({
-  agentId: "your-agent-id",
-  xApiKey: "your-api-key",
-  variables: {
-    callee_name: "John",
-    account_id: "ACC-42",
-  },
-  defaultTab: "audio",
-  hideTabSelector: false,
-  title: "Talk to our assistant",
-  description: "Ask a question or start a voice call.",
-  buttons: {
-    modalTrigger: {
-      styles: {
-        backgroundColor: "#4F46E5",
-        color: "white",
-        borderRadius: "50%",
-      },
-    },
-    call: {
-      textBeforeCall: "Start Call",
-      textDuringCall: "End Call",
-    },
-  },
-  widgetPosition: {
-    triggerPlacement: "fixed",
-    triggerAlignment: "bottom-right",
-    hideTriggerOnExpand: true,
-    widgetAlignment: "bottom-right",
-  },
-});
-```
-
-The sections below list the supported options for positioning, trigger button styling, chat mode, feedback screens, and interactive widgets.
-
-**_Step 4: Add the Code to Your Website_**
-
-Paste the embed code into your website's HTML, preferably just before the closing `</body>` tag.
-
-**_Step 5: Configure CDN Permissions_**
-
-If your website uses Content Security Policy (CSP), add the following CDN links to your security policies:
-
-```text
-style-src: https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@latest/dist/style.css
-script-src: https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@latest/dist/dv-agent.es.js
-```
-
-If you pin a CDN version, update the CSP entries to match that exact version.
-
-**_Step 6: Test the Integration_**
-
-* Visit your website
-
-* Look for the Web Call button (typically in the bottom right corner)
-
-* Click the button to start a call
-
-* Speak to test the voice interaction
-
-
-## Widget Positioning
-
-Control where the widget appears on your page. Supported from v1.0.19+.
-
-## Fixed Mode (Default)
-
-The widget floats over your page, fixed to the browser viewport. No additional setup required.
-
-## Absolute Mode
-
-Embed the widget inside a specific container on your page.
-
-**_Step 1: Add a container with the required ID_**
-
-```html
-<div id="ringg_ai_container" style="position: relative; width: 100%; height: 500px;">
-</div>
-```
-
-**_Step 2: Enable absolute positioning_**
-
-```javascript
-loadAgent({
-  agentId: "your-agent-id",
-  xApiKey: "your-api-key",
-  widgetPosition: {
-    triggerPlacement: "absolute",
-    triggerAlignment: "center"
-  }
-});
-```
-
-<Card>
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `triggerPlacement` | `string` | `"fixed"` | `"fixed"` for viewport, `"absolute"` for container |
-| `triggerAlignment` | `string` | `"bottom-right"` | Trigger button position |
-| `hideTriggerOnExpand` | `boolean` | `true` | Hide trigger when widget is open |
-| `widgetAlignment` | `string` | `"bottom-right"` | Expanded widget position |
-</Card>
-
-
-## Trigger Button Customization
-
-Customize the floating action button that opens the widget. Supported from v1.0.19+.
-
-## Button Styles
-
-```javascript
-buttons: {
-  modalTrigger: {
-    styles: {
-      backgroundColor: "#4F46E5",
-      width: 64,
-      height: 64
-    }
-  }
-}
-```
-
-## Custom Icon
-
-```javascript
-buttons: {
-  modalTrigger: {
-    icon: {
-      url: "https://example.com/my-icon.svg",
-      size: 24
-    }
-  }
-}
-```
-
-<Card>
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `styles` | `CSSProperties` | — | Button CSS styles (width, height, backgroundColor, etc.) |
-| `icon.url` | `string` | Ringg phone icon | Custom icon URL |
-| `icon.size` | `number` | `20` | Icon size in pixels |
-</Card>
-
-
-## Widget Events
-
-Subscribe to widget events and perform your custom actions based on them. Supported from v1.0.17.
-
-<Card>
-| Event | Payload |
-|-------|---------|
-| `ringg:widget_status` | `status`: `"maximised"` \| `"minimised"`<br/>`mode`: `"audio"` \| `"text"` |
-| `ringg:conversation_status` | `status`: `"started"` \| `"ended"`<br/>`mode`: `"audio"` \| `"text"`<br/>`callId`: `string` |
-| `ringg:feedback_status` | `status`: `"submitted"` \| `"skipped"`<br/>`callId`: `string`<br/>`rating?`: `number` |
-</Card>
-
-## Usage
-
-```javascript
-window.addEventListener("ringg:widget_status", (e) => {
-  console.log(e.detail); // { status: "maximised", mode: "audio" }
-});
-
-window.addEventListener("ringg:conversation_status", (e) => {
-  console.log(e.detail); // { status: "started", mode: "audio", callId: "abc123" }
-});
-
-window.addEventListener("ringg:feedback_status", (e) => {
-  console.log(e.detail); // { status: "submitted", callId: "abc123", rating: 5 }
-});
-```
-
----
-
-## Chat Agent (Text Mode)
-
-The Ringg widget supports a **text-based chat mode** alongside voice calls. In chat mode, the AI assistant handles conversations through typed messages instead of audio, while still supporting interactive widgets like callback scheduling, form collection, and all configured tools.
-
-### Setting Up a Chat Agent
-
-<Tip>
-**Best Practice**: Create a dedicated assistant for chat by cloning your voice assistant in the Ringg AI dashboard. This lets you tailor the prompt specifically for text-based interactions — chat conversations are typically longer, more detailed, and benefit from a different conversational style than voice calls.
-</Tip>
-
-**To set up a chat agent:**
-
-1. Open the Ringg AI dashboard and navigate to your assistants.
-2. Clone your existing voice assistant (or create a new one).
-3. Update the cloned assistant's prompt to be optimized for chat — e.g., include structured responses, markdown formatting, and instructions for when to present widgets like the callback scheduler.
-4. Configure any chat-specific tools or widgets (calendar for callback scheduling, forms for data collection).
-5. Use the cloned assistant's `agentId` in the embed code with `defaultTab: "text"`.
-
-### Enabling Chat Mode
-
-Set `defaultTab` to `"text"` when loading the agent to open the widget in chat mode by default:
-
-```javascript
-loadAgent({
-  agentId: "your-chat-agent-id",
-  xApiKey: "your-api-key",
-  defaultTab: "text",
-});
-```
-
-### Chat-Only Mode
-
-To create a chat-only widget with no voice tab, hide the tab selector:
-
-```javascript
-loadAgent({
-  agentId: "your-chat-agent-id",
-  xApiKey: "your-api-key",
-  defaultTab: "text",
-  hideTabSelector: true,
-});
-```
-
-### Dual Mode (Voice + Chat)
-
-You can also offer both voice and chat in the same widget. Users can switch between tabs freely:
-
-```javascript
-loadAgent({
-  agentId: "your-agent-id",
-  xApiKey: "your-api-key",
-  defaultTab: "audio",
-  hideTabSelector: false,
-});
-```
-
-### How Chat Mode Works
-
-The chat agent uses the same underlying assistant configuration as voice mode with these key differences:
-
-- **Input/Output**: Text messages instead of audio streams. Audio input and output are disabled; transcription-based text communication is enabled.
-- **Context Compression**: Long chat conversations are automatically compressed to manage token limits, keeping the conversation flowing without hitting model context limits.
-- **RAG Summarization**: Knowledge base query results are summarized in chat mode to reduce token usage and provide concise answers.
-- **Interactive Widgets**: Chat mode is especially powerful with widgets — the assistant can present callback scheduling calendars, data collection forms, and other interactive components directly in the chat window.
-- **Same Tools**: All configured tools (API integrations, knowledge base queries, widgets, etc.) work identically in chat mode.
-
-<Card>
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `defaultTab` | `"audio" \| "text"` | `"audio"` | Tab shown when the widget loads. Use `"text"` for chat mode. Supported from v1.0.8+ |
-| `hideTabSelector` | `boolean` | `false` | Hides the audio/text tab switcher for a single-mode experience. Supported from v1.0.8+ |
-| `bypassStartScreen` | `boolean` | `false` | Skips the start screen and begins a call/chat immediately on trigger click. Uses the `defaultTab` mode. |
-</Card>
-
----
-
-## Chat Widgets
-
-Chat widgets are interactive UI components that the AI assistant can present to users during a conversation. They render directly inside the chat interface, enabling structured interactions like **scheduling a callback**, collecting form data, or booking appointments — all without leaving the chat.
-
-<Tip>
-Chat widgets work best in **text mode**. While they can also be triggered during voice calls, the visual interaction is most natural in the chat interface. Consider setting up a dedicated chat agent with widgets for the best user experience.
-</Tip>
-
-### Widget Types
-
-The assistant supports two built-in widget types:
-
-1. **Calendar Widget** — Ideal for **callback scheduling**, appointment booking, and demo scheduling. Presents available date and time slots for the user to select.
-2. **Form Widget** — Perfect for collecting structured data like contact details, lead information, support tickets, or survey responses.
-
-### How Widgets Work
-
-The widget interaction follows a seamless round-trip flow:
-
-1. During a conversation, the assistant determines it's the right moment to present a widget (e.g., the user asks to schedule a callback) and calls the `send_widgets` tool.
-2. The widget renders directly inside the chat interface.
-3. The user interacts with the widget (selects a time slot, fills out a form).
-4. The user's response is sent back to the assistant automatically.
-5. The assistant processes the response, optionally triggers an API call (e.g., to create a booking in your CRM), and continues the conversation with a confirmation.
-
-### Calendar Widget (Callback Scheduling)
-
-The calendar widget is the go-to solution for **callback scheduling** and appointment booking. It displays available time slots over a configurable number of days, and past slots are automatically excluded so users only see valid options.
-
-**Common use cases:**
-- Schedule a callback from a human agent
-- Book a product demo or consultation
-- Set up a follow-up appointment
-
-**Configuration fields:**
-
-<Card>
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `tool_type` | `string` | Yes | Must be `"calender_widget_tool"` |
-| `tool_id` | `string` | Yes | Unique identifier for this widget instance |
-| `slot_duration_days` | `integer` | Yes | Number of days to show slots for (e.g., `7`) |
-| `slot_interval_minutes` | `integer` | Yes | Minutes between each slot (e.g., `30`) |
-| `start_time_24_hour_format` | `string` | Yes | Slot start time in `HH:MM` format (e.g., `"09:00"`) |
-| `end_time_24_hour_format` | `string` | Yes | Slot end time in `HH:MM` format (e.g., `"17:00"`) |
-| `timezone` | `string` | Yes | IANA timezone (e.g., `"Asia/Kolkata"`) |
-| `api_config` | `object` | No | Optional API to call when the user selects a slot |
-</Card>
-
-**Example: Callback scheduling configuration (passed in assistant metadata):**
-
-```json
-{
-  "tool_type": "calender_widget_tool",
-  "tool_id": "callback_scheduler",
-  "slot_duration_days": 7,
-  "slot_interval_minutes": 30,
-  "start_time_24_hour_format": "09:00",
-  "end_time_24_hour_format": "17:00",
-  "timezone": "Asia/Kolkata",
-  "api_config": {
-    "url": "https://your-api.com/schedule-callback",
-    "method": "POST",
-    "headers": {
-      "Authorization": "Bearer your-token",
-      "Content-Type": "application/json"
-    },
-    "body": {}
-  }
-}
-```
-
-**What happens when a user schedules a callback:**
-
-1. The assistant presents the calendar widget with available slots.
-2. The user picks a date and time.
-3. The selected datetime and timezone are sent back to the assistant.
-4. If `api_config` is provided, the booking data is automatically forwarded to your API (e.g., to create a callback entry in your CRM or scheduling system).
-5. The assistant confirms the booking to the user in a human-readable format (e.g., "Your callback has been scheduled for Monday, March 2nd at 10:30 AM IST").
-
-### Form Widget (Data Collection)
-
-The form widget renders a dynamic form with multiple field types directly inside the chat. It is ideal for collecting structured information that would be tedious to gather through back-and-forth messages.
-
-**Common use cases:**
-- Collect contact details or lead information
-- Gather shipping/billing addresses
-- Capture support ticket details
-- Run quick surveys or preference questionnaires
-
-**Configuration fields:**
-
-<Card>
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `tool_type` | `string` | Yes | Must be `"form_widget_tool"` |
-| `tool_id` | `string` | Yes | Unique identifier for this widget instance |
-| `title` | `string` | Yes | Title displayed at the top of the form |
-| `submit_button_label` | `string` | Yes | Text on the submit button (e.g., `"Submit"`) |
-| `form_fields` | `array` | Yes | Array of field definitions (see below) |
-| `api_config` | `object` | No | Optional API to call when the form is submitted |
-</Card>
-
-**Form field definition:**
-
-<Card>
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `key` | `string` | Yes | Unique field identifier |
-| `type` | `string` | Yes | Field type (e.g., `"text"`, `"email"`, `"select"`, `"number"`) |
-| `description` | `string` | Yes | Label/placeholder text for the field |
-| `required` | `boolean` | Yes | Whether the field is mandatory |
-| `options` | `array` | No | Options list for select/dropdown fields |
-</Card>
-
-**Example configuration:**
-
-```json
-{
-  "tool_type": "form_widget_tool",
-  "tool_id": "contact_form",
-  "title": "Contact Information",
-  "submit_button_label": "Submit Details",
-  "form_fields": [
-    {
-      "key": "full_name",
-      "type": "text",
-      "description": "Full Name",
-      "required": true,
-      "options": []
-    },
-    {
-      "key": "email",
-      "type": "email",
-      "description": "Email Address",
-      "required": true,
-      "options": []
-    },
-    {
-      "key": "preferred_plan",
-      "type": "select",
-      "description": "Preferred Plan",
-      "required": false,
-      "options": ["Basic", "Pro", "Enterprise"]
-    }
-  ],
-  "api_config": {
-    "url": "https://your-api.com/contacts",
-    "method": "POST",
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "body": {}
-  }
-}
-```
-
-When the user submits the form, the collected data is sent back to the assistant. If an `api_config` is provided, the data is also forwarded to your API endpoint.
-
-### Complete Example: Chat Agent with Callback Scheduling
-
-Here is a full example of embedding a chat-only assistant with callback scheduling enabled:
-
-```html
-<script>
-  function loadAgentsCdn(e, t) {
-    let n = document.createElement("link");
-    n.rel = "stylesheet", n.type = "text/css", n.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${e}/dist/style.css`;
-    var a = document.createElement("script");
-    a.type = "text/javascript", a.onload = function() { t() },
-    a.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${e}/dist/dv-agent.es.js`,
-    document.getElementsByTagName("head")[0].appendChild(n),
-    document.getElementsByTagName("head")[0].appendChild(a)
-  }
-</script>
-
-<script>
-  loadAgentsCdn("latest", function() {
+## Quickstart
+
+<Steps>
+  <Step title="Configure the assistant for web calls">
+    Open the assistant in the Ringg AI dashboard, go to the WebCall settings, and add your website domain to **Whitelist Domains**.
+
+    Add staging domains separately, such as `staging.example.com`, instead of using one broad production-only assumption.
+  </Step>
+
+  <Step title="Add the widget snippet">
+    Paste this near the end of the page, preferably before the closing `</body>` tag.
+
+    ```html
+    <script>
+      function loadAgentsCdn(version, done) {
+        const stylesheet = document.createElement("link");
+        stylesheet.rel = "stylesheet";
+        stylesheet.type = "text/css";
+        stylesheet.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/style.css`;
+
+        const script = document.createElement("script");
+        script.type = "text/javascript";
+        script.onload = done;
+        script.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/dv-agent.es.js`;
+
+        document.head.appendChild(stylesheet);
+        document.head.appendChild(script);
+      }
+
+      loadAgentsCdn("latest", function () {
+        loadAgent({
+          agentId: "your-agent-id",
+          xApiKey: "your-api-key",
+          variables: {},
+          buttons: {},
+        });
+      });
+    </script>
+    ```
+
+    For production, pin a tested CDN version instead of `latest` after validating the widget in staging.
+  </Step>
+
+  <Step title="Set the first configuration options">
+    Keep the first launch small. Add variables and the default mode first, then layer on styling.
+
+    ```javascript
     loadAgent({
-      agentId: "your-chat-agent-id",
+      agentId: "your-agent-id",
       xApiKey: "your-api-key",
-
-      // Chat-only mode
-      defaultTab: "text",
-      hideTabSelector: true,
-
-      // Branding
-      title: "Support Chat",
-      description: "Hi! I can help you schedule a callback or answer your questions.",
-      logoUrl: "https://example.com/your-logo.svg",
-
-      // Widget appearance
-      buttons: {
-        modalTrigger: {
-          styles: {
-            backgroundColor: "#4F46E5",
-          },
-          icon: {
-            url: "https://example.com/chat-icon.svg",
-            size: 24,
-          },
-        },
+      variables: {
+        callee_name: "John",
+        account_id: "ACC-42",
       },
-
-      // Feedback after conversation
-      feedbackScreen: {
-        title: "How was your chat?",
-        description: "Your feedback helps us improve!",
-        submitBtnCTA: "Submit",
-      },
+      defaultTab: "audio",
+      hideTabSelector: false,
+      title: "Talk to our assistant",
+      description: "Ask a question or start a voice call.",
     });
-  });
-</script>
-```
+    ```
+  </Step>
 
-The calendar and form widgets are configured in the assistant's metadata through the Ringg AI dashboard — no additional frontend code is needed. See the prompt examples below for how to instruct the assistant to use them.
+  <Step title="Update Content Security Policy if needed">
+    If your site uses CSP, allow the widget CDN for scripts and styles.
 
----
+    ```text
+    script-src 'self' https://cdn.jsdelivr.net;
+    style-src 'self' https://cdn.jsdelivr.net;
+    ```
 
-## Prompt Examples for Chat Agents
+    If your CSP policy pins exact asset URLs, use the same CDN version in both the loader and the CSP entries.
+  </Step>
+</Steps>
 
-Your assistant's prompt (configured in the Ringg AI dashboard) controls when and how it uses widgets. Below are ready-to-use prompt examples for common chat scenarios.
+## Configuration basics
 
-### Chat Agent with Callback Scheduling
+| Option | Use it for |
+|---|---|
+| `agentId` | The Ringg assistant to load in the widget. |
+| `xApiKey` | The widget API key from the dashboard embed code. |
+| `variables` | Runtime values passed into the assistant prompt, such as names or account IDs. |
+| `defaultTab` | `"audio"` for voice first or `"text"` for chat first. |
+| `hideTabSelector` | Set `true` for voice-only or chat-only experiences. |
+| `buttons` | Trigger button and call button styling or labels. |
+| `widgetPosition` | Fixed floating widget or absolute placement inside a page container. |
 
-```text
-You are a friendly support assistant for [Company Name]. You help users with
-their questions and can schedule callbacks with our team.
+See the [configuration reference](/get-started/guides/embedding-widget-configuration) for the full option set and examples.
 
-Guidelines:
-- Greet the user warmly and ask how you can help.
-- Answer questions using the knowledge base when available.
-- If the user wants to speak to a human agent, schedule a call, or book a demo,
-  present the calendar widget so they can pick a convenient time slot.
-- After the user selects a time slot, confirm the booking with the date, time,
-  and timezone in a clear, human-readable format.
-- Keep responses concise and conversational — this is a chat, not an email.
-```
+## Test checklist
 
-### Chat Agent with Form Collection
+<Check>The widget script and stylesheet load without console errors.</Check>
+<Check>The trigger button appears in the expected location on desktop and mobile.</Check>
+<Check>Voice mode asks for microphone permission and can start and end a test call.</Check>
+<Check>Chat mode opens if `defaultTab` is set to `"text"`.</Check>
+<Check>The domain is whitelisted in the assistant WebCall settings.</Check>
+<Check>Your CSP allows the pinned CDN script and stylesheet.</Check>
+<Check>Events or analytics listeners fire only once per user action.</Check>
 
-```text
-You are a lead qualification assistant for [Company Name]. Your goal is to
-understand the user's needs and collect their contact information.
-
-Guidelines:
-- Start by understanding what the user is looking for.
-- Once you have enough context about their needs, present the contact form
-  widget to collect their details (name, email, phone, preferred plan).
-- After the form is submitted, thank the user and let them know a team member
-  will follow up shortly.
-- Do not ask for information that the form will collect — let the form handle it.
-```
-
-### Chat Agent with Both Calendar and Form
-
-```text
-You are a customer support assistant for [Company Name]. You can help users
-with questions, collect information, and schedule callbacks.
-
-Guidelines:
-- Greet the user and ask how you can help.
-- For general questions, answer directly using available knowledge.
-- If the user needs to speak with a human agent or wants a demo:
-  → Present the calendar widget to schedule a callback.
-- If the user wants to submit a request, provide feedback, or share details:
-  → Present the form widget to collect their information.
-- Always confirm the action after a widget interaction (e.g., "Your callback
-  is booked for Tuesday at 2:00 PM" or "Thanks! We've received your details").
-- Keep responses short and friendly.
-```
-
-### Tips for Writing Chat Prompts
-
-- **Be explicit about when to use widgets** — tell the assistant exactly which situations should trigger the calendar or form widget.
-- **Don't duplicate widget fields in conversation** — if the form collects the user's email, don't ask for it in chat first.
-- **Confirm after widget interactions** — instruct the assistant to acknowledge bookings and form submissions clearly.
-- **Keep it conversational** — chat prompts should produce shorter, more casual responses than voice prompts.
+For launch readiness, use the [production QA and security checklist](/get-started/guides/embedding-widget-production-qa-security).

--- a/get-started/guides/manage-numbers.mdx
+++ b/get-started/guides/manage-numbers.mdx
@@ -1,45 +1,39 @@
 ---
 title: "Manage Numbers"
 sidebarTitle: "Manage Numbers"
-description: "Buy numbers, bring your own telephony, and manage your existing phone lines."
+description: "Buy, connect, assign, and remove phone numbers in Ringg AI."
 icon: "hash"
 ---
 
-Numbers are the telephony lines your assistants use to make and receive calls. This guide covers buying numbers, bringing your own, and managing your existing ones.
+Numbers are the phone lines your assistants use to make and receive calls. You can use Ringg AI numbers or connect numbers from your own telephony provider.
 
 ---
 
-## Viewing Your Numbers
+## View Numbers
 
 1. Click **Numbers** in the left sidebar.
-2. You'll see a list of all numbers in your workspace.
-
-{/* <Frame>
-  <img src="/images/documentation/numbers-page.png" alt="Numbers Page" />
-</Frame> */}
+2. Review the numbers in your workspace.
 
 Each row shows:
-- **Phone number** (with a copy icon)
-- **Country** flag
-- **Date added**
-- **Used By** — which assistant is assigned to this number (blank if unassigned)
-- **Tags** — e.g. `Default Number`
+
+| Field | Meaning |
+|---|---|
+| **Phone number** | The full caller number |
+| **Country** | The number's country |
+| **Date added** | When the number was added |
+| **Used By** | Which assistant or campaign is using it |
+| **Tags** | Labels such as `Default Number` |
 
 ---
 
-## Buying a New Number
+## Buy a New Number
 
-<Steps>
-  <Step title="Click Buy New Number">
-    On the Numbers page, click **Buy new number** (top-right).
-  </Step>
-  <Step title="Select Number Details">
-    Follow the purchase flow to select a country, area code, and number type.
-  </Step>
-  <Step title="Confirm Purchase">
-    Confirm the purchase. The number will appear in your list immediately.
-  </Step>
-</Steps>
+1. On the **Numbers** page, click **Buy new number**.
+2. Choose the country, area, and number type if those options are available.
+3. Review the purchase details.
+4. Confirm the purchase.
+
+The number appears in your workspace after the purchase completes.
 
 <Note>
   Number availability and pricing depend on the country and telephony provider.
@@ -47,54 +41,71 @@ Each row shows:
 
 ---
 
-## Bring Your Own Telephony (BYOT)
+## Bring Your Own Telephony
 
-If you have existing numbers with a third-party provider (Twilio, Exotel, etc.), you can connect them via **Integrations**.
+Use **Bring Your Own Telephony** when your company already owns numbers with a provider such as Twilio, Exotel, or Plivo.
 
-<Steps>
-  <Step title="Go to Integrations">
-    Go to **Integrations** in the left sidebar.
-  </Step>
-  <Step title="Add New Provider">
-    On the **Your Telephony** tab, click **Add New**.
-  </Step>
-  <Step title="Select Provider">
-    Select your provider from the dropdown.
-  </Step>
-  <Step title="Enter Credentials">
-    Enter your provider credentials.
-  </Step>
-  <Step title="Save">
-    Save. Your numbers from that provider will appear in the Numbers list.
-  </Step>
-</Steps>
+1. Click **Integrations** in the left sidebar.
+2. Open the **Your Telephony** tab.
+3. Click **Add New**.
+4. Choose the provider.
+5. Enter the provider credentials.
+6. Click **Save**.
+7. Return to **Numbers** and confirm the numbers appear.
 
-The **Telephony** dropdown at the top of the Numbers page shows which provider is active (e.g. "Ringg").
+The **Telephony** dropdown at the top of the Numbers page shows the active provider.
 
 ---
 
-## Setting a Default Number
+## Set a Default Number
 
-If a number is tagged as **Default Number**, it is used automatically when no specific number is assigned to a campaign.
+A number tagged as **Default Number** is used when no specific number is selected.
 
-To tag a number as default:
-1. Click the tag icon next to the number.
-2. Add the tag `Default Number`.
+1. Find the number on the **Numbers** page.
+2. Click the tag action.
+3. Add the tag `Default Number`.
+4. Save the change.
+
+Use one default number per workspace unless your operations team has a specific routing plan.
 
 ---
 
-## Removing a Number
+## Assign Numbers to Campaigns
 
-Click **Remove** next to any number to remove it from your workspace.
+You choose caller numbers while creating a campaign.
+
+1. Open or create the campaign.
+2. In the **Numbers** field, select one or more numbers.
+3. Save the campaign.
+
+Multiple numbers can spread call volume across caller IDs.
+
+For **Inbound** assistants, the assigned number is the number customers dial.
+
+---
+
+## Remove a Number
+
+1. Confirm the number is not used by a live campaign or inbound assistant.
+2. Click **Remove** next to the number.
+3. Confirm the removal.
 
 <Warning>
-  Removing a number that is actively used in a running campaign will interrupt those calls. Always pause or complete campaigns before removing numbers.
+  Removing a number that is used by a running campaign or inbound assistant can interrupt calls. Pause campaigns or reassign assistants before removing it.
 </Warning>
 
 ---
 
-## Assigning Numbers to Campaigns
+## Developer Handoff
 
-Numbers are assigned during campaign creation in the **Numbers** field. You can assign multiple numbers to distribute call load — the system will rotate through them.
+If engineers will make API calls or configure routing, send them:
 
-For **Inbound** assistants, the assigned number is the one contacts dial into.
+| Item | Why They Need It |
+|---|---|
+| Phone number | Helps confirm the visible caller ID |
+| Number provider | Tells them whether the number is Ringg AI-owned or from your telephony provider |
+| `from_number_id` | Preferred identifier for outbound API calls when available |
+| `from_number` | Use only when the API flow expects the literal phone number |
+| Assigned assistant or campaign | Helps them confirm the number is used in the right place |
+
+For individual outbound API calls, exactly one caller-number option is required: `from_number_id` or `from_number`. Do not send both.

--- a/get-started/guides/view-call-history.mdx
+++ b/get-started/guides/view-call-history.mdx
@@ -1,113 +1,121 @@
 ---
 title: "View Call History"
 sidebarTitle: "View Call History"
-description: "Browse call logs, listen to recordings, and read transcripts."
+description: "Find call logs, recordings, transcripts, and call details."
 icon: "history"
 ---
 
-The **History** section gives you a full log of every call made or received by your assistants, including audio recordings and transcripts.
+Use **History** to review every call made or received by your assistants. This is where business teams check outcomes, listen to recordings, read transcripts, and export call data.
 
 ---
 
-## Accessing Call History
+## Open History
 
 1. Click **History** in the left sidebar.
-2. The page loads with calls from the last 30 days by default.
-
-{/* <Frame>
-  <img src="/images/documentation/history-page.png" alt="History Page" />
-</Frame> */}
+2. Review the default date range.
+3. Use filters if you need a smaller list.
 
 ---
 
-## Understanding the Call Log
+## Read the Call Log
 
-The table shows the following columns:
+The call table shows one row per call.
 
-| Column | Description |
+| Column | What It Means |
 |---|---|
-| **Direction** | Arrow icon — ↗ Outbound, ↙ Inbound |
-| **Assistant Name** | The assistant that handled the call (with version number) |
-| **Callee Name** | Contact's name and phone number |
+| **Direction** | Whether the call was outbound or inbound |
+| **Assistant Name** | The assistant that handled the call |
+| **Callee Name** | The contact name and phone number |
 | **Called On** | Date and time of the call |
-| **Call Status** | `Completed`, `Voicemail`, etc. |
-| **Call Duration** | Length of the call in seconds |
+| **Call Status** | Outcome such as completed, failed, no answer, or voicemail |
+| **Call Duration** | How long the call lasted |
+
+Click any row to open the call details panel.
 
 ---
 
-## Filtering Calls
+## Filter Calls
 
-### By Date Range
+Use filters when you are looking for a specific call or campaign result.
 
-Click the **date picker** (e.g. `2026-02-07 – 2026-03-09`) to adjust the date range. Click the ✕ to reset to the default range.
+### Date Range
 
-### By Other Filters
+1. Click the date range picker.
+2. Choose the start and end dates.
+3. Apply the range.
+4. Click the clear icon to reset if needed.
 
-Click **Filter** to open the filter panel and narrow results by:
-- Assistant
-- Call status
-- Call direction
-- And more
+### Other Filters
 
----
+Click **Filter** and narrow the list by:
 
-## Exporting Call History
-
-Click **Export** (top-right) to download the filtered call list as a CSV file. Use this for reporting, audits, or CRM uploads.
-
----
-
-## Viewing a Call's Details
-
-Click any row to open the **Call Analysis** panel on the right.
-
-{/* <Frame>
-  <img src="/images/documentation/call-analysis-panel.png" alt="Call Analysis Panel" />
-</Frame> */}
-
-### Call Summary
-
-The top of the panel shows:
-- **Assistant name** and direction (Outbound/Inbound)
-- **Call ID** (UUID, with copy button)
-- **Call Time** — when the call was made
-- **Call Duration** — in seconds
-- **Call Status** — e.g. Completed
-
-### Audio Playback
-
-An audio waveform player lets you listen to the full call recording. Click ▶ to play, and use the download button to save the audio file.
+- Assistant.
+- Call status.
+- Call direction.
+- Campaign or list, when available.
+- Other available fields.
 
 ---
 
-## Call Details Tab
+## Export Call History
 
-Click **Call Details** to see structured metadata:
+1. Apply the filters you want.
+2. Click **Export**.
+3. Download the CSV.
 
-| Field | Description |
+Use exports for reports, audits, CRM uploads, QA review, or offline analysis.
+
+---
+
+## Review a Call
+
+Click a call row to open the **Call Analysis** panel.
+
+The panel includes:
+
+| Section | What You Can Do |
 |---|---|
-| **Call Latency** | Time (in seconds) before the assistant's first utterance began |
-| **Call Duration** | Start and end timestamps |
-| **Custom Variables** | The values injected for this specific call (e.g. `Mrp: 50000`) |
+| Summary | Check assistant, direction, call time, duration, and status |
+| Call ID | Copy the unique ID for support or developer debugging |
+| Recording | Play or download the audio recording |
+| Call Details | Review latency, timestamps, and custom variables |
+| Transcript | Read the conversation |
+| Analysis | Review extracted fields if custom analysis is configured |
 
 ---
 
-## Transcript Tab
+## Use the Transcript
 
-Click **Transcript** to read the full conversation.
+Click **Transcript** in the call details panel.
 
-{/* <Frame>
-  <img src="/images/documentation/call-transcript.png" alt="Call Transcript" />
-</Frame> */}
+Use the transcript to:
 
-The transcript shows:
-- Each turn of the conversation with speaker labels (assistant vs. callee)
-- **Phase labels** at the start of each section (e.g. `Greetings ~32.6ms`) showing the prompt node that was active
-- Timestamps for each message
-- A **copy** and **download** button to export the transcript
+- Confirm what the assistant said.
+- Review customer objections.
+- Check whether the assistant followed the prompt.
+- Copy examples for prompt improvements.
+- Share evidence with sales, support, compliance, or operations teams.
 
 ---
 
-## Sharing a Call
+## Share a Call
 
-Use the **link icon** in the Call Analysis panel header to generate a shareable URL for this specific call — useful for team review or escalation.
+Use the link icon in the call details panel to create a shareable URL for one call.
+
+Share call links only with people who should have access to customer conversations and recordings.
+
+---
+
+## Developer Handoff
+
+If engineers are investigating a call or connecting results to another system, send them:
+
+| Item | Why They Need It |
+|---|---|
+| `call_id` | Links dashboard history, API history, webhooks, and support logs |
+| Assistant name and `agent_id` | Helps confirm which assistant handled the call |
+| Campaign name or `bulk_list_id` | Helps find all calls from the same campaign |
+| Call status and timestamp | Speeds up debugging |
+| Transcript or recording link | Helps verify prompt behavior and webhook payloads |
+
+For real-time results, ask the developer to use webhooks. History is best for review, exports, audits, and backfills.

--- a/get-started/guides/view-history.mdx
+++ b/get-started/guides/view-history.mdx
@@ -1,113 +1,121 @@
 ---
 title: "View Call History"
 sidebarTitle: "View Call History"
-description: "Browse call logs, listen to recordings, and read transcripts."
+description: "Find call logs, recordings, transcripts, and call details."
 icon: "history"
 ---
 
-The **History** section gives you a full log of every call made or received by your assistants, including audio recordings and transcripts.
+Use **History** to review every call made or received by your assistants. This is where business teams check outcomes, listen to recordings, read transcripts, and export call data.
 
 ---
 
-## Accessing Call History
+## Open History
 
 1. Click **History** in the left sidebar.
-2. The page loads with calls from the last 30 days by default.
-
-{/* <Frame>
-  <img src="/images/documentation/history-page.png" alt="History Page" />
-</Frame> */}
+2. Review the default date range.
+3. Use filters if you need a smaller list.
 
 ---
 
-## Understanding the Call Log
+## Read the Call Log
 
-The table shows the following columns:
+The call table shows one row per call.
 
-| Column | Description |
+| Column | What It Means |
 |---|---|
-| **Direction** | Arrow icon — ↗ Outbound, ↙ Inbound |
-| **Assistant Name** | The assistant that handled the call (with version number) |
-| **Callee Name** | Contact's name and phone number |
+| **Direction** | Whether the call was outbound or inbound |
+| **Assistant Name** | The assistant that handled the call |
+| **Callee Name** | The contact name and phone number |
 | **Called On** | Date and time of the call |
-| **Call Status** | `Completed`, `Failed`, `No Answer`, `Voicemail`, etc. |
-| **Call Duration** | Length of the call in seconds |
+| **Call Status** | Outcome such as completed, failed, no answer, or voicemail |
+| **Call Duration** | How long the call lasted |
+
+Click any row to open the call details panel.
 
 ---
 
-## Filtering Calls
+## Filter Calls
 
-### By Date Range
+Use filters when you are looking for a specific call or campaign result.
 
-Click the **date picker** (e.g. `2026-02-07 – 2026-03-09`) to adjust the date range. Click the ✕ to reset to the default range.
+### Date Range
 
-### By Other Filters
+1. Click the date range picker.
+2. Choose the start and end dates.
+3. Apply the range.
+4. Click the clear icon to reset if needed.
 
-Click **Filter** to open the filter panel and narrow results by:
-- Assistant
-- Call status
-- Call direction
-- And more
+### Other Filters
 
----
+Click **Filter** and narrow the list by:
 
-## Exporting Call History
-
-Click **Export** (top-right) to download the filtered call list as a CSV file. Use this for reporting, audits, or CRM uploads.
-
----
-
-## Viewing a Call's Details
-
-Click any row to open the **Call Analysis** panel on the right.
-
-{/* <Frame>
-  <img src="/images/documentation/call-analysis-panel.png" alt="Call Analysis Panel" />
-</Frame> */}
-
-### Call Summary
-
-The top of the panel shows:
-- **Assistant name** and direction (Outbound/Inbound)
-- **Call ID** (UUID, with copy button)
-- **Call Time** — when the call was made
-- **Call Duration** — in seconds
-- **Call Status** — e.g. Completed
-
-### Audio Playback
-
-An audio waveform player lets you listen to the full call recording. Click ▶ to play, and use the download button to save the audio file.
+- Assistant.
+- Call status.
+- Call direction.
+- Campaign or list, when available.
+- Other available fields.
 
 ---
 
-## Call Details Tab
+## Export Call History
 
-Click **Call Details** to see structured metadata:
+1. Apply the filters you want.
+2. Click **Export**.
+3. Download the CSV.
 
-| Field | Description |
+Use exports for reports, audits, CRM uploads, QA review, or offline analysis.
+
+---
+
+## Review a Call
+
+Click a call row to open the **Call Analysis** panel.
+
+The panel includes:
+
+| Section | What You Can Do |
 |---|---|
-| **Call Latency** | Time (in seconds) before the assistant's first utterance began |
-| **Call Duration** | Start and end timestamps |
-| **Custom Variables** | The values injected for this specific call (e.g. `Mrp: 50000`) |
+| Summary | Check assistant, direction, call time, duration, and status |
+| Call ID | Copy the unique ID for support or developer debugging |
+| Recording | Play or download the audio recording |
+| Call Details | Review latency, timestamps, and custom variables |
+| Transcript | Read the conversation |
+| Analysis | Review extracted fields if custom analysis is configured |
 
 ---
 
-## Transcript Tab
+## Use the Transcript
 
-Click **Transcript** to read the full conversation.
+Click **Transcript** in the call details panel.
 
-{/* <Frame>
-  <img src="/images/documentation/call-transcript.png" alt="Call Transcript" />
-</Frame> */}
+Use the transcript to:
 
-The transcript shows:
-- Each turn of the conversation with speaker labels (assistant vs. callee)
-- **Phase labels** at the start of each section (e.g. `Greetings ~32.6ms`) showing the prompt node that was active
-- Timestamps for each message
-- A **copy** and **download** button to export the transcript
+- Confirm what the assistant said.
+- Review customer objections.
+- Check whether the assistant followed the prompt.
+- Copy examples for prompt improvements.
+- Share evidence with sales, support, compliance, or operations teams.
 
 ---
 
-## Sharing a Call
+## Share a Call
 
-Use the **link icon** in the Call Analysis panel header to generate a shareable URL for this specific call — useful for team review or escalation.
+Use the link icon in the call details panel to create a shareable URL for one call.
+
+Share call links only with people who should have access to customer conversations and recordings.
+
+---
+
+## Developer Handoff
+
+If engineers are investigating a call or connecting results to another system, send them:
+
+| Item | Why They Need It |
+|---|---|
+| `call_id` | Links dashboard history, API history, webhooks, and support logs |
+| Assistant name and `agent_id` | Helps confirm which assistant handled the call |
+| Campaign name or `bulk_list_id` | Helps find all calls from the same campaign |
+| Call status and timestamp | Speeds up debugging |
+| Transcript or recording link | Helps verify prompt behavior and webhook payloads |
+
+For real-time results, ask the developer to use webhooks. History is best for review, exports, audits, and backfills.

--- a/get-started/guides/workspace-settings.mdx
+++ b/get-started/guides/workspace-settings.mdx
@@ -1,167 +1,168 @@
 ---
 title: "Workspace Settings"
 sidebarTitle: "Workspace Settings"
-description: "Manage workspace members, API keys, and integrations."
+description: "Manage workspace members, API keys, telephony, and app integrations."
 icon: "building"
 ---
 
-This guide covers the three workspace-level settings: **Workspace Members**, **API Key**, and **Integrations**.
+Workspace settings control team access, API access, and integrations that affect the whole Ringg AI workspace.
 
 ---
 
 ## Workspace Members
 
-### Accessing Workspace Members
+Use **Workspace Members** to invite teammates and control what they can change.
 
-Click **Workspace Members** in the left sidebar (under "More").
+### View Members
 
-{/* <Frame>
-  <img src="/images/documentation/workspace-members.png" alt="Workspace Members Page" />
-</Frame> */}
+1. Click **Workspace Members** in the left sidebar under **More**.
+2. Review the member list.
 
-The table shows all current members with:
-- **Name** and **Owner** badge (for the account owner)
-- **Email** address
-- **Permissions** level
-- **Status** (Success = active invitation)
+The table shows each member's name, email, permission level, owner status, and invitation status.
 
-### Inviting a New Member
+### Invite a Member
 
-<Steps>
-  <Step title="Click Invite Member">
-    Click **Invite Member** (top-right).
-  </Step>
-  <Step title="Enter Email">
-    Enter the member's email address.
-  </Step>
-  <Step title="Set Permissions">
-    Set their permission level.
-  </Step>
-  <Step title="Send Invitation">
-    Send the invitation. They'll receive an email to join the workspace.
-  </Step>
-</Steps>
+1. Click **Invite Member**.
+2. Enter the teammate's email address.
+3. Choose the permission level.
+4. Send the invitation.
 
 ### Permission Levels
 
-| Permission | Description |
+| Permission | Use It For |
 |---|---|
-| **View & Edit** | Can view and modify all assets (assistants, campaigns, etc.) |
-| **View Only** | Can view assets but cannot create or modify |
+| **View & Edit** | Teammates who create or update assistants, campaigns, numbers, or settings |
+| **View Only** | Teammates who only need to review history, analytics, or configuration |
 
-Click the permission dropdown next to any member to change their access level.
+### Remove a Member
 
-### Removing a Member
-
-Click **Remove User** next to any non-owner member to revoke their access immediately.
+1. Find the member in the table.
+2. Click **Remove User**.
+3. Confirm the removal.
 
 <Note>
-  You cannot remove yourself as the workspace Owner. Transfer ownership before leaving a workspace.
+  You cannot remove the workspace owner from the workspace. Transfer ownership first if ownership needs to change.
 </Note>
 
 ---
 
 ## API Key
 
-### Accessing Your API Key
+Use **API Key** when engineers need to connect Ringg AI to your product, CRM, website, or data systems.
 
-Click **API Key** in the left sidebar.
+### Copy the API Key
 
-{/* <Frame>
-  <img src="/images/documentation/api-key-page.png" alt="API Key Page" />
-</Frame> */}
+1. Click **API Key** in the left sidebar.
+2. Click the eye icon only if you need to reveal the key.
+3. Click the copy icon to copy it.
+4. Send it to the developer through your company's approved secret-sharing process.
 
-Your workspace **X-API-KEY** is displayed (masked by default).
-
-### Using the API Key
-
-The API key is required to authenticate all programmatic calls to the Ringg AI API. Include it as a header:
+The API key is sent as the `X-API-KEY` header in Ringg AI API requests.
 
 ```http
 X-API-KEY: $RINGG_API_KEY
 ```
 
-Click the **copy icon** to copy the key to your clipboard.
-Click the **eye icon** to reveal the full key on screen.
-
-### Regenerating the API Key
-
-Click **Regenerate** to create a new API key.
-
 <Warning>
-  Regenerating invalidates the old key immediately. Any existing integrations using the old key will stop working. Update all systems before regenerating.
+  Treat the API key as a secret. Do not paste it into public tickets, docs, chat channels, frontend code, screenshots, or emails.
 </Warning>
 
-### API Documentation
+### Regenerate the API Key
 
-Click the **Docs** link to access the full Ringg AI API reference.
+Click **Regenerate** only when you intentionally want to rotate the key.
+
+Regenerating immediately invalidates the old key. Coordinate with developers before rotating so existing integrations do not break.
+
+### Open API Docs
+
+Click **Docs** to open the Ringg AI API reference.
 
 ---
 
 ## Integrations
 
-Click **Integrations** in the left sidebar. There are two tabs:
+Click **Integrations** in the left sidebar.
 
-### Your Telephony (Bring Your Own Telephony)
+Integrations connect Ringg AI to telephony providers and workflow tools.
 
-Connect your own telephony provider to use your existing phone numbers.
+---
 
-{/* <Frame>
-  <img src="/images/documentation/integrations-telephony.png" alt="Telephony Integration" />
-</Frame> */}
+## Your Telephony
 
-<Steps>
-  <Step title="Click Add New">
-    Click **Add New**.
-  </Step>
-  <Step title="Select Provider">
-    Select your provider from the **All** dropdown (e.g. Twilio, Exotel, Plivo).
-  </Step>
-  <Step title="Enter Credentials">
-    Enter your provider's API credentials.
-  </Step>
-  <Step title="Save">
-    Save. Your numbers will sync to the **Numbers** page.
-  </Step>
-</Steps>
+Use **Your Telephony** when your company wants to use its own provider numbers.
+
+1. Open **Integrations**.
+2. Click the **Your Telephony** tab.
+3. Click **Add New**.
+4. Choose the provider, such as Twilio, Exotel, or Plivo.
+5. Enter the provider credentials.
+6. Click **Save**.
+7. Open **Numbers** and confirm the provider numbers appear.
 
 <Note>
-  If you don't connect a custom provider, Ringg AI uses its own telephony by default.
+  If you do not connect a custom telephony provider, Ringg AI uses the default Ringg AI telephony setup.
 </Note>
 
-### Zapier
+---
 
-Connect Ringg AI to thousands of other apps through Zapier workflows.
+## Zapier
 
-{/* <Frame>
-  <img src="/images/documentation/integrations-zapier.png" alt="Zapier Integration" />
-</Frame> */}
+Use **Zapier** when business users want to connect Ringg AI to other apps without a custom backend.
 
-**Popular pre-built workflows:**
+Common examples:
 
 <CardGroup cols={2}>
-  <Card title="Google Sheets → Ringg AI" icon="table">
-    Initiate Ringg AI calls when new rows are added in Google Sheets — great for dynamic calling lists
+  <Card title="Google Sheets to Ringg AI" icon="table">
+    Start a Ringg AI action when a new row appears in a sheet.
   </Card>
-  <Card title="Shopify → Ringg AI" icon="shopping-cart">
-    Initiate Ringg AI calls for new Shopify orders — automate order confirmations or delivery updates
+  <Card title="Shopify to Ringg AI" icon="shopping-cart">
+    Start customer calls for new orders or delivery updates.
   </Card>
 </CardGroup>
 
-**To connect:**
+To connect:
 
-<Steps>
-  <Step title="Sign Up or Log In">
-    Click **Sign up** to create a Zapier account, or **Log in** if you already have one.
-  </Step>
-  <Step title="Select Apps">
-    In the "Connect this app" field, **Ringg AI** is pre-selected. Search for the app you want to connect in the "with this one!" field.
-  </Step>
-  <Step title="Create Your Zap">
-    Follow Zapier's guided setup to create your Zap.
-  </Step>
-</Steps>
+1. Open **Integrations**.
+2. Go to **Zapier**.
+3. Click **Sign up** or **Log in**.
+4. Choose Ringg AI and the app you want to connect.
+5. Follow Zapier's setup steps.
 
 <Tip>
-  Your Ringg AI API key is used to authenticate the Zapier connection.
+  Zapier may ask for the Ringg AI API key. Use the same secret-handling rules as any backend integration.
 </Tip>
+
+---
+
+## Webhook Setup Handoff
+
+Webhooks send call results to another system automatically. Business users usually decide what should happen; developers usually configure the endpoint.
+
+Give developers:
+
+| Item | Why They Need It |
+|---|---|
+| Business goal | Example: send completed call results to CRM |
+| Assistant name and `agent_id` | Webhook subscriptions are configured for an assistant |
+| Events needed | Examples: call status, recording, transcript, analysis, all processing completed |
+| Destination system | CRM, support tool, data warehouse, Google Sheets, or another backend |
+| Receiver URL owner | The team that owns the webhook endpoint |
+| API key | Needed to configure the subscription through the API |
+
+Developers can follow [Webhook setup](/webhooks/initial-setup).
+
+---
+
+## Developer Handoff
+
+For workspace-level setup, send developers:
+
+| Item | Use |
+|---|---|
+| Workspace API key | Server-side API authentication |
+| Telephony provider | Confirms whether calls use Ringg AI telephony or BYOT |
+| Workspace members with edit access | Confirms who can change production settings |
+| Number list | Helps map caller IDs to campaigns and products |
+| Webhook requirements | Defines what post-call data should be delivered automatically |
+
+Ask developers to store the API key in a secret manager and to tell you before they regenerate or rotate it.

--- a/get-started/key-concepts/assistants.mdx
+++ b/get-started/key-concepts/assistants.mdx
@@ -1,36 +1,50 @@
 ---
 title: "Assistants"
 sidebarTitle: "Assistants"
-description: "Understand the core building block of Ringg AI — AI-powered voice agents that conduct phone conversations on your behalf."
+description: "Understand Ringg AI assistants and how teams use them."
 icon: "bot-message-square"
 ---
 
-An **Assistant** is the core building block of Ringg AI. It is an AI-powered voice agent that conducts phone conversations on your behalf, following a defined objective, script, and voice persona.
+An **Assistant** is the Ringg AI voice agent that talks to customers. It follows your script, uses the voice you choose, and works toward the goal you define.
 
 ---
 
-## Assistant Types
+## What an Assistant Does
 
-### By Orchestration
+An assistant can:
 
-| Type | Description | Best For |
+- Call contacts from a campaign.
+- Answer calls made to your number.
+- Speak with website visitors through a webcall widget.
+- Use uploaded documents to answer questions.
+- Save call results for review in History and Analytics.
+
+---
+
+## Call Direction
+
+| Direction | What It Means | Common Use |
 |---|---|---|
-| **Single Prompt** | One unified prompt drives the entire conversation | Simple, linear workflows (e.g. reminders, quick surveys) |
-| **Multi Prompt** | Multiple prompt nodes form a branching conversation flow | Complex workflows with conditional paths (e.g. loan collections, onboarding) |
-
-### By Call Direction
-
-| Direction | Description |
-|---|---|
-| **Outbound** | The assistant dials the contact's number |
-| **Inbound** | The assistant answers calls made to your number |
-| **Webcall** | The assistant handles calls initiated from a web widget embedded on your site |
+| **Outbound** | Ringg AI calls the contact | Campaigns, reminders, follow-ups, collections |
+| **Inbound** | The customer calls your number | Support, intake, routing, callbacks |
+| **Webcall** | A website visitor starts the call online | Product pages, landing pages, onboarding |
 
 ---
 
-## Industry Templates
+## Conversation Style
 
-When creating an assistant, you can choose from pre-built industry templates:
+| Style | What It Means | Best For |
+|---|---|---|
+| **Single Prompt** | One script controls the whole call | Simple flows with one goal |
+| **Multi Prompt** | Multiple prompt nodes guide different paths | Complex flows with branching logic |
+
+Start with **Single Prompt** unless the conversation clearly needs branches.
+
+---
+
+## Templates
+
+Ringg AI includes industry templates for common use cases.
 
 <CardGroup cols={3}>
   <Card title="Logistics" icon="truck" />
@@ -42,69 +56,55 @@ When creating an assistant, you can choose from pre-built industry templates:
 </CardGroup>
 
 <Tip>
-  Templates pre-populate prompt structures suited to that industry, saving setup time.
+  Templates are starting points. Review the prompt and edit it for your company, audience, and compliance needs.
 </Tip>
 
 ---
 
-## Assistant Settings
+## Main Settings
 
-Every assistant has the following configurable settings:
-
-### Assistant Settings
-
-| Setting | Description |
+| Setting | What You Control |
 |---|---|
-| **Prompt** | The first message the assistant speaks, the conversation objective, and response guidelines |
-| **Voice** | Language (primary + secondary) and voice character (Tanya, Naina, Raj, Rahul, Anya, etc.) |
-| **Custom Variables** | Dynamic variables injected into the prompt at call time (e.g. `{{callee_name}}`, `{{mrp}}`) |
-| **Knowledge Base** | Attach a Knowledge Base so the assistant can look up information during calls |
-
-### Call Settings
-
-| Setting | Description |
-|---|---|
-| **Call** | Maximum call duration, inactivity timeout, timezone, noise filtering, voicemail detection, retry logic, and audio behaviour |
-| **Chat** | Session duration and idle timeout settings for webcall/chat interactions |
-
-### Advanced Settings
-
-| Setting | Description |
-|---|---|
-| **Embed** | Widget configuration and auto-generated embed code for webcall integration |
-| **Keyword Boosting** | Add domain-specific words to improve the assistant's speech recognition accuracy |
-| **Custom Analysis** | Define a post-call analysis prompt and output schema to extract structured data from each call |
+| **Prompt** | Opening line, goal, tone, and rules |
+| **Voice** | Language and voice character |
+| **Custom Variables** | Contact-specific values such as `callee_name` or `loan_amount` |
+| **Knowledge Base** | Documents the assistant can use during calls |
+| **Call Settings** | Duration, timezone, voicemail behavior, retries, and audio settings |
+| **Embed** | Website widget setup for webcall assistants |
+| **Custom Analysis** | Post-call fields to extract from transcripts |
 
 ---
 
-## The Prompt Structure
+## Prompt Basics
 
-A well-structured prompt typically contains:
+A good prompt has three parts:
 
 <Steps>
-  <Step title="First Message">
-    The exact opening line the assistant speaks when the call connects. Supports `@{{variable}}` syntax for dynamic personalisation.
+  <Step title="First message">
+    The exact line the assistant says when the call connects.
   </Step>
   <Step title="Objective">
-    A paragraph describing the assistant's role, context, and goals.
+    The assistant's role, business context, and goal.
   </Step>
-  <Step title="Response Guidelines">
-    Rules for tone, persona, length of responses, and language switching.
+  <Step title="Response guidelines">
+    Rules for tone, language, objections, handoff, and answer length.
   </Step>
 </Steps>
 
-<Note>
-  The **Interruptible** toggle on the first message controls whether the callee can speak before the assistant finishes its opening line.
-</Note>
+Variables such as `@{{callee_name}}` let the assistant personalize each call.
 
 ---
 
 ## Agent ID
 
-Every assistant gets a unique **Agent ID** (UUID). This is used for API calls and integrations.
+Every assistant has an `agent_id`. Developers use it for API calls, campaigns, webhooks, and webcall embeds.
+
+<Note>
+  When a business user creates or approves an assistant, include the assistant name and `agent_id` in the developer handoff.
+</Note>
 
 ---
 
-## Test Call
+## Test Calls
 
-Use the **Test call** button (top-right of any assistant page) to trigger a live test call before deploying to a campaign.
+Use **Test call** before launch. Test the first message, voice, language switching, knowledge base answers, custom analysis, and end-of-call behavior.

--- a/get-started/key-concepts/campaigns.mdx
+++ b/get-started/key-concepts/campaigns.mdx
@@ -1,83 +1,101 @@
 ---
 title: "Campaigns"
 sidebarTitle: "Campaigns"
-description: "Learn about campaigns — scheduled batches of outbound calls made by your AI assistants."
+description: "Understand outbound calling campaigns in Ringg AI."
 icon: "notebook-tabs"
 ---
 
-A **Campaign** is a scheduled batch of outbound calls made by a selected assistant to a list of contacts. Campaigns let you automate high-volume outreach without manual dialling.
+A **Campaign** is a scheduled group of outbound calls. Ringg AI uses one assistant, one or more caller numbers, and a contact list to call many people without manual dialing.
 
 ---
 
-## Campaign Overview
+## What a Campaign Needs
 
-The Campaigns page shows all your campaigns in a table with the following columns:
-
-| Column | Description |
+| Item | Why It Matters |
 |---|---|
-| **Campaign** | Campaign name (with a copy icon) |
-| **Status** | Current state: `Completed`, `Ongoing`, `Scheduled`, `Paused`, or `Failed` |
-| **Total Calls** | Number of calls made in this campaign |
-| **Campaign Time** | Scheduled start → end date and time |
-| **Actions** | View history or manage the campaign |
-
-{/* <Frame>
-  <img src="/images/documentation/campaigns-list.png" alt="Campaigns List" />
-</Frame> */}
+| Assistant | Controls what the call says and how it behaves |
+| Caller number | Shows as the number calling the contact |
+| Calling list | Contains phone numbers and optional custom variables |
+| Schedule | Sets when calls start and stop |
+| Timezone | Makes the schedule clear for your audience |
+| Credits | Pays for call time |
 
 ---
 
 ## Campaign Settings
 
-When creating a campaign, you configure two tabs:
+When creating a campaign, you fill in two main sections.
 
-### Tab 1 — Campaign Settings
+### Campaign Settings
 
-| Field | Description |
+| Field | Meaning |
 |---|---|
-| **Campaign Name** | A label to identify this campaign |
-| **Assistant** | The AI voice agent that will make the calls |
-| **Numbers** | One or more telephony numbers to dial from |
-| **Campaign Start Date/Time** | When the campaign starts making calls |
-| **Campaign End Date/Time** | When the campaign stops, even if there are remaining contacts |
-| **Timezone** | The timezone for scheduling (e.g. UTC+5:30 IST) |
-| **Email Notifications** | Workspace members who receive campaign status updates |
+| **Campaign Name** | Business-friendly label for the campaign |
+| **Assistant** | Voice agent that will make the calls |
+| **Numbers** | Caller IDs used for dialing |
+| **Campaign Start Date/Time** | When Ringg AI can start calling |
+| **Campaign End Date/Time** | When Ringg AI must stop calling |
+| **Timezone** | Timezone for the schedule |
+| **Email Notifications** | People who receive campaign updates |
 
-### Tab 2 — Calling List
+### Calling List
 
-Upload the list of contacts the campaign will call. Typically a CSV with columns for phone number and any custom variables used in your assistant's prompt (e.g. `callee_name`, `mrp`).
+The calling list is usually a CSV file. It should include:
+
+- A phone number column.
+- Any custom variables used in the assistant prompt.
+- Clean headers with no extra spaces.
+
+Example: if the assistant says `@{{callee_name}}`, the CSV needs a `callee_name` column.
+
+---
+
+## Campaign Status
+
+| Status | Meaning |
+|---|---|
+| `Scheduled` | The campaign is waiting for its start time |
+| `Ongoing` | Calls are currently being made |
+| `Paused` | Calling has been paused |
+| `Completed` | The campaign finished or reached its end time |
+| `Failed` | The campaign hit an error that needs attention |
 
 ---
 
 ## Campaign Concurrency
 
-**Concurrency** controls how many simultaneous calls a campaign can make.
+Concurrency controls how many calls can happen at the same time.
 
-Click **Manage Concurrency** on the Campaigns page to configure:
+Use **Manage Concurrency** when:
 
-### Workspace Concurrency
-
-Sets the split between API-initiated calls and campaign calls:
-
-- **API Concurrency** — Percentage of workspace capacity reserved for API calls (default: 100%)
-- **Campaign Concurrency** — Percentage allocated to campaigns (default: 0%)
+- Multiple campaigns are running at once.
+- API-triggered calls and dashboard campaigns share the same workspace capacity.
+- You want to control how call slots are split across campaigns.
 
 <Note>
-  If Campaign Concurrency is 0%, campaign concurrency is distributed equally across all running campaigns.
+  If campaign concurrency is not set manually, Ringg AI distributes available campaign call slots across running campaigns.
 </Note>
-
-### Campaigns Concurrency
-
-When multiple campaigns run simultaneously, this tab lets you manually allocate concurrent call slots per campaign.
 
 ---
 
-## Campaign Status Reference
+## Developer Handoff
 
-| Status | Meaning |
+Developers need campaign IDs to start, monitor, and reconcile calls outside the dashboard.
+
+| Item | Why Developers Need It |
 |---|---|
-| `Scheduled` | Campaign is queued and hasn't started yet |
-| `Ongoing` | Campaign is actively making calls |
-| `Paused` | Campaign has been manually paused |
-| `Completed` | Campaign has finished (reached end time or called all contacts) |
-| `Failed` | Campaign encountered a fatal error |
+| `agent_id` | Assistant that should handle the calls |
+| Caller number or `from_number_id` | Caller ID for the campaign |
+| CSV column names | Must match assistant custom variables |
+| `bulk_list_id` or list ID | Identifies the uploaded contact list |
+| Campaign ID | Identifies the saved campaign |
+| Webhook events | Sends results to another system automatically |
+
+For the standard API flow, developers should use `POST /campaign/save` and then `POST /campaign/start`.
+
+For 5,000 or more rows, developers should use the beta large-campaign flow:
+
+1. `POST /campaign/upload-csv`
+2. `GET /campaign/upload-status/{bulk_list_id}`
+3. `POST /campaign/make-call-async`
+4. `POST /campaign/check-balance/{bulk_list_id}`

--- a/get-started/key-concepts/knowledge-base.mdx
+++ b/get-started/key-concepts/knowledge-base.mdx
@@ -1,44 +1,45 @@
 ---
 title: "Knowledge Base"
 sidebarTitle: "Knowledge Base"
-description: "Learn about Knowledge Bases — document collections your assistants can search during live calls."
+description: "Understand knowledge bases and when to use them."
 icon: "folder-git-2"
 ---
 
-A **Knowledge Base (KB)** is a collection of documents that an assistant can search during a live call to retrieve accurate information. This is useful when your assistant needs to answer questions about products, policies, pricing, or FAQs that can't be hardcoded into a prompt.
+A **Knowledge Base** is a set of approved documents an assistant can use during a call. It helps the assistant answer questions from the right source instead of relying only on the prompt.
+
+---
+
+## When to Use a Knowledge Base
+
+Use a knowledge base when the assistant needs to answer from:
+
+- FAQs.
+- Pricing or plan details.
+- Product catalogs.
+- Policy documents.
+- Eligibility rules.
+- Support scripts.
+- Standard operating procedures.
+
+Do not use a knowledge base as a replacement for a clear prompt. The prompt still tells the assistant when and how to use the information.
 
 ---
 
 ## Knowledge Base Types
 
-Ringg AI offers two types of Knowledge Bases:
-
 <CardGroup cols={2}>
-  <Card title="Deterministic KB">
-    <span style={{color: "gray"}}>More accurate results. You choose what to search.</span>
-
-    - You define the exact fields/schema that will be queried
-    - Best for structured data (e.g. product catalogues, pricing tables, policy documents)
-    - Higher accuracy because the retrieval logic is explicit
+  <Card title="Deterministic KB" icon="list-checks">
+    Use this for structured data where you define the exact fields to retrieve.
   </Card>
-  <Card title="Non-Deterministic KB">
-    <span style={{color: "gray"}}>More flexible. AI figures it out, but may be less accurate.</span>
-
-    - The AI decides what to search and how to answer
-    - Best for unstructured documents (e.g. FAQs, knowledge articles, SOPs)
-    - More flexible but may occasionally return less precise results
+  <Card title="Non Deterministic KB" icon="file-search">
+    Use this for general documents where Ringg AI searches for the most relevant answer.
   </Card>
 </CardGroup>
 
----
-
-## Attaching a KB to an Assistant
-
-Once a Knowledge Base is created, you can attach it to any assistant via **Assistant Settings → Knowledge Base**.
-
-<Tip>
-  Multiple assistants can share the same Knowledge Base.
-</Tip>
+| Type | Best For | Tradeoff |
+|---|---|---|
+| **Deterministic KB** | Pricing tables, policy fields, product catalogs, eligibility rules | More setup, more predictable answers |
+| **Non Deterministic KB** | FAQs, articles, manuals, SOPs | Faster setup, but answers may need more testing |
 
 ---
 
@@ -46,13 +47,33 @@ Once a Knowledge Base is created, you can attach it to any assistant via **Assis
 
 | Limit | Value |
 |---|---|
-| Max files per KB | 4 files |
-| Max file size | 512 MB each |
+| Files per knowledge base | Up to 4 |
+| File size | Up to 512 MB per file |
+
+Use focused files with clear headings. Remove outdated or conflicting content before upload.
 
 ---
 
-## Schema (Deterministic KB)
+## Attach to Assistants
 
-For Deterministic KBs, you define a schema that maps the fields in your uploaded documents. Click **Edit Schema** during KB creation to configure field names and types.
+After training a knowledge base, attach it to an assistant from **Assistant Settings** and then **Knowledge Base**.
 
-After uploading your files, click **Train Knowledge Base** to process the data and make it available to your assistants.
+<Tip>
+  Multiple assistants can use the same knowledge base, but every assistant should be tested after attachment.
+</Tip>
+
+---
+
+## Developer Handoff
+
+If your product or backend needs to reference knowledge base setup, send developers:
+
+| Item | Why It Matters |
+|---|---|
+| Knowledge base name | Confirms the right document set |
+| Knowledge base type | Explains the retrieval behavior |
+| Assistant name and `agent_id` | Confirms where the KB is attached |
+| Source document owner | Identifies who approves changes |
+| Test questions | Helps QA the assistant and support workflows |
+
+If engineers store knowledge base IDs, ask them to retrieve the current ID after training is complete.

--- a/get-started/key-concepts/numbers.mdx
+++ b/get-started/key-concepts/numbers.mdx
@@ -1,58 +1,85 @@
 ---
 title: "Numbers"
 sidebarTitle: "Numbers"
-description: "Learn about telephony numbers — the phone lines your assistants use to make and receive calls."
+description: "Understand caller numbers and how assistants use them."
 icon: "hash"
 ---
 
-**Numbers** are the telephony phone numbers your assistants use to make and receive calls. Ringg AI supports both purchased numbers and numbers from your own telephony provider (Bring Your Own Telephony).
+**Numbers** are the phone lines Ringg AI uses to make and receive calls. A number can come from Ringg AI or from your own telephony provider.
 
 ---
 
-## Numbers Overview
+## What Numbers Are Used For
 
-The Numbers page lists all numbers in your workspace with the following details:
-
-| Column | Description |
+| Use Case | How the Number Is Used |
 |---|---|
-| **Number** | The full phone number (e.g. +918031136540) |
-| **Country** | Flag icon indicating the country of the number |
-| **Added On** | Date and time the number was added |
-| **Used By** | Which assistant is currently assigned to this number |
-| **Tags** | Labels for organising numbers (e.g. Default Number) |
+| Outbound campaign | Shows as the caller ID when Ringg AI dials contacts |
+| Individual outbound call | Identifies the caller number for one API-triggered call |
+| Inbound assistant | Receives calls from customers |
+| Webcall | May be used behind the scenes depending on setup |
 
-{/* <Frame>
-  <img src="/images/documentation/numbers-page.png" alt="Numbers Page" />
-</Frame> */}
+---
+
+## Numbers Page
+
+The **Numbers** page lists the phone numbers in your workspace.
+
+| Field | Meaning |
+|---|---|
+| **Number** | Full phone number |
+| **Country** | Number country |
+| **Added On** | When the number was added |
+| **Used By** | Assistant or campaign currently using the number |
+| **Tags** | Labels such as `Default Number` |
 
 ---
 
 ## Telephony Provider
 
-At the top of the Numbers page, a **Telephony** dropdown shows which provider your numbers are routed through (e.g. Ringg). This can be changed via **Integrations → Your Telephony**.
+The **Telephony** dropdown shows which provider routes your numbers.
+
+Use **Integrations** and then **Your Telephony** if you need to connect a provider such as Twilio, Exotel, or Plivo.
 
 ---
 
 ## Default Number
 
+A number tagged as **Default Number** is used when no specific number is selected.
+
 <Note>
-  Numbers tagged as **Default Number** are automatically used by assistants when no specific number is assigned.
+  Confirm the default number before launching campaigns. The wrong default caller ID can affect answer rates and customer trust.
 </Note>
 
 ---
 
 ## Number Assignment
 
-Numbers are assigned to assistants when creating a **Campaign**. An assistant uses the selected number(s) as the caller ID when dialling contacts.
+You select numbers while creating campaigns. Campaigns can use multiple numbers to distribute call volume.
 
-For **Inbound** assistants, the number is the one that contacts call into.
+Inbound assistants need a number that customers can dial.
 
 ---
 
-## Removing a Number
+## Removing Numbers
 
-Click **Remove** next to any number to delete it from your workspace.
+Remove a number only after confirming it is not used by a live campaign, scheduled campaign, or inbound assistant.
 
 <Warning>
-  Removing a number that is actively used by a running campaign will interrupt those calls.
+  Removing a number that is actively used can interrupt calls.
 </Warning>
+
+---
+
+## Developer Handoff
+
+Developers may need number details for API calls, routing, and troubleshooting.
+
+| Item | Why It Matters |
+|---|---|
+| Phone number | Human-readable caller ID |
+| `from_number_id` | Preferred API identifier when available |
+| `from_number` | Literal phone number used by some API flows |
+| Provider | Confirms whether the number is Ringg AI-owned or BYOT |
+| Assigned assistant or campaign | Confirms where the number is used |
+
+For individual outbound API calls, send exactly one caller-number option: `from_number_id` or `from_number`. Do not send both.

--- a/get-started/overview/dashboard-overview.mdx
+++ b/get-started/overview/dashboard-overview.mdx
@@ -1,85 +1,118 @@
 ---
 title: "Dashboard"
 sidebarTitle: "Dashboard"
-description: "Learn how to navigate the Ringg AI dashboard and workspace."
+description: "Learn how to navigate the Ringg AI dashboard."
 icon: "panels-top-left"
 ---
 
-When you log in to Ringg AI, you land on the **Assistants** page — the main hub of your workspace.
+The Ringg AI dashboard is where your team creates assistants, launches campaigns, manages numbers, reviews calls, and checks performance.
 
-{/* <Frame>
-  <img src="/images/documentation/dashboard-overview.png" alt="Dashboard Overview" />
-</Frame> */}
+When you log in, you usually land on **Assistants**.
 
 ---
 
-## Layout
+## Main Navigation
 
-The dashboard has two main areas:
+Use the left sidebar to move between product areas.
 
-### Left Sidebar — Navigation
-
-The sidebar is split into two groups:
-
-**App**
-
-| Item | Description |
+| Section | What You Do There |
 |---|---|
-| Assistants | View, create, and manage all your AI voice agents |
-| Campaigns | Create and schedule bulk outbound call campaigns |
-| Knowledge Base | Upload reference documents for your assistants |
-| Numbers | Manage purchased or imported telephony numbers |
-| History | Browse individual call logs and transcripts |
-| Analytics | View aggregate call performance metrics |
+| **Assistants** | Create and manage voice assistants |
+| **Campaigns** | Schedule outbound calling campaigns |
+| **Knowledge Base** | Upload documents assistants can use during calls |
+| **Numbers** | Buy, connect, and manage caller numbers |
+| **History** | Review calls, recordings, transcripts, and exports |
+| **Analytics** | Track call volume, connection rates, cost, and outcomes |
+| **Workspace Members** | Invite teammates and manage permissions |
+| **API Key** | Copy or rotate the workspace API key |
+| **Integrations** | Connect telephony providers and tools such as Zapier |
+| **Contact Us** | Reach the Ringg AI support team |
 
-**More**
+---
 
-| Item | Description |
+## Top Bar
+
+The top bar helps you confirm where you are and which workspace you are using.
+
+| Item | What It Means |
 |---|---|
-| Workspace Members | Add/remove team members and set their permissions |
-| API Key | View and regenerate your workspace API key |
-| Integrations | Connect telephony providers (BYOT) and Zapier |
-| Contact Us | Reach the Ringg AI support team |
-
----
-
-### Top Bar
-
-- **Workspace selector** (top-left) — Switch between workspaces if you belong to multiple
-- **Credit balance** (top-right, shown in orange) — Your current call credit balance in ₹
-- **Breadcrumb** (center-top) — Shows your current location, e.g. `Dashboard > Assistants`
-
----
-
-### Main Content Area
-
-The main panel changes based on the section you're in. For **Assistants**, you'll see:
-
-- A **Search** bar to filter assistants by name
-- A filter dropdown (**All** / **Inbound** / **Outbound**)
-- A **+ Create Assistant** button (top-right)
-- Assistant cards grouped by **This week**, **Last month**, and **Older**
-
-Each assistant card shows:
-- Assistant **avatar** and **name**
-- Assistant type (**Single Prompt** or **Multi Prompt**)
-- Call direction (**Outbound**, **Inbound**, or **Webcall**)
-- Total **Calls** made by that assistant
-
-{/* <Frame>
-  <img src="/images/documentation/assistants-list.png" alt="Assistants List" />
-</Frame> */}
-
----
-
-## Workspace Switcher
-
-If you manage multiple workspaces (e.g. different clients or environments), click the **workspace name** in the top-left corner to switch.
-
----
-
-## Credit Balance
+| **Workspace selector** | Switches between workspaces if you belong to more than one |
+| **Breadcrumb** | Shows the current page path |
+| **Credit balance** | Shows available prepaid calling credits |
 
 <Note>
-  The orange balance (e.g. ₹38,133.6) in the top-right is your current prepaid call credit. Credits are consumed based on call duration. Contact the Ringg AI team to top up.
+  Credits are consumed by calls. Contact the Ringg AI team when you need a top-up.
 </Note>
+
+---
+
+## Assistants Page
+
+The **Assistants** page is the main starting point.
+
+Use it to:
+
+- Search for an assistant.
+- Filter assistants by inbound, outbound, or webcall.
+- Create a new assistant.
+- Open an existing assistant.
+- Check how many calls an assistant has handled.
+
+Each assistant card shows the assistant name, type, call direction, and call count.
+
+---
+
+## Typical Dashboard Flow
+
+For most teams, the first setup follows this order:
+
+<Steps>
+  <Step title="Create an assistant">
+    Build the voice agent that will speak to customers.
+  </Step>
+  <Step title="Configure the assistant">
+    Add the prompt, voice, custom variables, knowledge base, and test calls.
+  </Step>
+  <Step title="Add numbers">
+    Buy or connect the caller numbers the assistant will use.
+  </Step>
+  <Step title="Launch a campaign">
+    Upload a CSV list and start outbound calls.
+  </Step>
+  <Step title="Review results">
+    Use History and Analytics to check outcomes and improve the setup.
+  </Step>
+</Steps>
+
+---
+
+## Where to Find Common Tasks
+
+| Task | Go To |
+|---|---|
+| Create a new voice agent | **Assistants** |
+| Upload a list and start calls | **Campaigns** |
+| Add customer FAQs or pricing documents | **Knowledge Base** |
+| Buy or connect phone numbers | **Numbers** |
+| Listen to a recording | **History** |
+| Download call results | **History** |
+| Check connection rate | **Analytics** |
+| Invite a teammate | **Workspace Members** |
+| Give a developer API access | **API Key** |
+| Set up webhooks or telephony | **Integrations** and developer API docs |
+
+---
+
+## Developer Handoff
+
+Some dashboard work creates values engineers need later.
+
+| When You Create | Give Developers |
+|---|---|
+| Assistant | Assistant name and `agent_id` |
+| Campaign | Campaign name and `bulk_list_id` or campaign ID |
+| Number | Phone number and `from_number_id` when available |
+| API integration | Workspace API key through a secure secret-sharing process |
+| Webhook workflow | Assistant `agent_id`, events needed, and destination system |
+
+Use this handoff list when moving from dashboard setup to product or backend integration.

--- a/get-started/overview/dashboard.mdx
+++ b/get-started/overview/dashboard.mdx
@@ -1,85 +1,118 @@
 ---
 title: "Dashboard"
 sidebarTitle: "Dashboard"
-description: "Learn how to navigate the Ringg AI dashboard and workspace."
+description: "Learn how to navigate the Ringg AI dashboard."
 icon: "panels-top-left"
 ---
 
-When you log in to Ringg AI, you land on the **Assistants** page — the main hub of your workspace.
+The Ringg AI dashboard is where your team creates assistants, launches campaigns, manages numbers, reviews calls, and checks performance.
 
-{/* <Frame>
-  <img src="/images/documentation/dashboard-overview.png" alt="Dashboard Overview" />
-</Frame> */}
+When you log in, you usually land on **Assistants**.
 
 ---
 
-## Layout
+## Main Navigation
 
-The dashboard has two main areas:
+Use the left sidebar to move between product areas.
 
-### Left Sidebar — Navigation
-
-The sidebar is split into two groups:
-
-**App**
-
-| Item | Description |
+| Section | What You Do There |
 |---|---|
-| Assistants | View, create, and manage all your AI voice agents |
-| Campaigns | Create and schedule bulk outbound call campaigns |
-| Knowledge Base | Upload reference documents for your assistants |
-| Numbers | Manage purchased or imported telephony numbers |
-| History | Browse individual call logs and transcripts |
-| Analytics | View aggregate call performance metrics |
+| **Assistants** | Create and manage voice assistants |
+| **Campaigns** | Schedule outbound calling campaigns |
+| **Knowledge Base** | Upload documents assistants can use during calls |
+| **Numbers** | Buy, connect, and manage caller numbers |
+| **History** | Review calls, recordings, transcripts, and exports |
+| **Analytics** | Track call volume, connection rates, cost, and outcomes |
+| **Workspace Members** | Invite teammates and manage permissions |
+| **API Key** | Copy or rotate the workspace API key |
+| **Integrations** | Connect telephony providers and tools such as Zapier |
+| **Contact Us** | Reach the Ringg AI support team |
 
-**More**
+---
 
-| Item | Description |
+## Top Bar
+
+The top bar helps you confirm where you are and which workspace you are using.
+
+| Item | What It Means |
 |---|---|
-| Workspace Members | Add/remove team members and set their permissions |
-| API Key | View and regenerate your workspace API key |
-| Integrations | Connect telephony providers (BYOT) and Zapier |
-| Contact Us | Reach the Ringg AI support team |
-
----
-
-### Top Bar
-
-- **Workspace selector** (top-left) — Switch between workspaces if you belong to multiple
-- **Credit balance** (top-right, shown in orange) — Your current call credit balance in ₹
-- **Breadcrumb** (center-top) — Shows your current location, e.g. `Dashboard > Assistants`
-
----
-
-### Main Content Area
-
-The main panel changes based on the section you're in. For **Assistants**, you'll see:
-
-- A **Search** bar to filter assistants by name
-- A filter dropdown (**All** / **Inbound** / **Outbound**)
-- A **+ Create Assistant** button (top-right)
-- Assistant cards grouped by **This week**, **Last month**, and **Older**
-
-Each assistant card shows:
-- Assistant **avatar** and **name**
-- Assistant type (**Single Prompt** or **Multi Prompt**)
-- Call direction (**Outbound**, **Inbound**, or **Webcall**)
-- Total **Calls** made by that assistant
-
-{/* <Frame>
-  <img src="/images/documentation/assistants-list.png" alt="Assistants List" />
-</Frame> */}
-
----
-
-## Workspace Switcher
-
-If you manage multiple workspaces (e.g. different clients or environments), click the **workspace name** in the top-left corner to switch.
-
----
-
-## Credit Balance
+| **Workspace selector** | Switches between workspaces if you belong to more than one |
+| **Breadcrumb** | Shows the current page path |
+| **Credit balance** | Shows available prepaid calling credits |
 
 <Note>
-  The orange balance (e.g. ₹38,133.6) in the top-right is your current prepaid call credit. Credits are consumed based on call duration. Contact the Ringg AI team to top up.
+  Credits are consumed by calls. Contact the Ringg AI team when you need a top-up.
 </Note>
+
+---
+
+## Assistants Page
+
+The **Assistants** page is the main starting point.
+
+Use it to:
+
+- Search for an assistant.
+- Filter assistants by inbound, outbound, or webcall.
+- Create a new assistant.
+- Open an existing assistant.
+- Check how many calls an assistant has handled.
+
+Each assistant card shows the assistant name, type, call direction, and call count.
+
+---
+
+## Typical Dashboard Flow
+
+For most teams, the first setup follows this order:
+
+<Steps>
+  <Step title="Create an assistant">
+    Build the voice agent that will speak to customers.
+  </Step>
+  <Step title="Configure the assistant">
+    Add the prompt, voice, custom variables, knowledge base, and test calls.
+  </Step>
+  <Step title="Add numbers">
+    Buy or connect the caller numbers the assistant will use.
+  </Step>
+  <Step title="Launch a campaign">
+    Upload a CSV list and start outbound calls.
+  </Step>
+  <Step title="Review results">
+    Use History and Analytics to check outcomes and improve the setup.
+  </Step>
+</Steps>
+
+---
+
+## Where to Find Common Tasks
+
+| Task | Go To |
+|---|---|
+| Create a new voice agent | **Assistants** |
+| Upload a list and start calls | **Campaigns** |
+| Add customer FAQs or pricing documents | **Knowledge Base** |
+| Buy or connect phone numbers | **Numbers** |
+| Listen to a recording | **History** |
+| Download call results | **History** |
+| Check connection rate | **Analytics** |
+| Invite a teammate | **Workspace Members** |
+| Give a developer API access | **API Key** |
+| Set up webhooks or telephony | **Integrations** and developer API docs |
+
+---
+
+## Developer Handoff
+
+Some dashboard work creates values engineers need later.
+
+| When You Create | Give Developers |
+|---|---|
+| Assistant | Assistant name and `agent_id` |
+| Campaign | Campaign name and `bulk_list_id` or campaign ID |
+| Number | Phone number and `from_number_id` when available |
+| API integration | Workspace API key through a secure secret-sharing process |
+| Webhook workflow | Assistant `agent_id`, events needed, and destination system |
+
+Use this handoff list when moving from dashboard setup to product or backend integration.

--- a/get-started/overview/ringg-ai.mdx
+++ b/get-started/overview/ringg-ai.mdx
@@ -11,22 +11,19 @@ Ringg AI gives your product programmable voice agents for outbound calls, inboun
 Use `X-API-KEY` only from trusted server-side code. Do not put workspace API keys in browser or mobile app source code unless you are using the managed Ringg web widget flow.
 </Warning>
 
-## Start building
+## Choose your path
 
-Pick the path that matches what you need to ship first.
+Start with the path that matches your role. Each path links to the smallest useful guide first, then to deeper reference pages.
 
-<CardGroup cols={2}>
-  <Card title="Make one outbound call" icon="phone-outgoing" href="/api-reference/quick-start/guide">
-    Validate authentication, choose an assistant and number, then call one user from your backend.
+<CardGroup cols={3}>
+  <Card title="Backend/API integration" icon="server-cog" href="/api-reference/quick-start/guide">
+    Make outbound calls, run campaigns, receive webhooks, query history, and build production backend workflows.
   </Card>
-  <Card title="Run a campaign" icon="list-start" href="/api-reference/tutorials/setting-up-bulk-calls">
-    Upload contacts, map variables, start bulk calls, and monitor campaign progress.
+  <Card title="Web widget integration" icon="globe" href="/get-started/guides/embedding-widget">
+    Embed Ringg voice or chat assistance in a website, then configure styling, events, chat widgets, CSP, and QA.
   </Card>
-  <Card title="Embed web calls" icon="globe-2" href="/get-started/guides/embedding-widget">
-    Add Ringg voice or chat assistance to a website with the hosted widget.
-  </Card>
-  <Card title="Receive call results" icon="webhook" href="/webhooks/initial-setup">
-    Subscribe to call, recording, analysis, and all-processing-completed webhook events.
+  <Card title="Dashboard setup" icon="layout-dashboard" href="/get-started/guides/create-assistant">
+    Create assistants, prompts, knowledge bases, numbers, campaigns, and analytics views without reading API docs first.
   </Card>
 </CardGroup>
 
@@ -43,7 +40,7 @@ Pick the path that matches what you need to ship first.
     Call `GET /agent/all` and select an assistant configured for your channel, such as outbound calls or web calls.
   </Step>
   <Step title="Choose a caller number" icon="hash">
-    Call `GET /workspace/numbers` and use a provisioned number as `from_number_id`, or rely on the assistant's default outbound number.
+    Call `GET /workspace/numbers` and use a provisioned number as `from_number_id`. The individual-call API requires exactly one caller-number option: `from_number_id` or `from_number`.
   </Step>
   <Step title="Initiate the call" icon="phone-call">
     Call `POST /calling/outbound/individual` with the recipient, assistant, caller number, and any `custom_args_values` your prompt uses.

--- a/telephony/number-management.mdx
+++ b/telephony/number-management.mdx
@@ -36,7 +36,7 @@ Once your provider is connected, you can import your existing numbers:
    <Step title="Select Provider Account">
     Choose the telephony provider account you want to import numbers from
 
-![Number Dashbaord](/images/number_dashboard.png)
+![Number Dashboard](/images/number_dashboard.png)
   </Step>
 
   <Step title="Select Numbers to Import">
@@ -45,7 +45,7 @@ Once your provider is connected, you can import your existing numbers:
   </Step>
   <Step title="Import Numbers">
     Click **"Import Selected Numbers"** to complete the import process
-    ![Number Dashbaord](/images/number_dashboard.png)
+    ![Number Dashboard](/images/number_dashboard.png)
   </Step>
 </Steps>
 
@@ -63,12 +63,12 @@ Ringg's marketplace allows you to purchase new phone numbers from multiple provi
    <Step title="Select Provider Account">
     Choose the telephony provider account you want to import numbers from
 
-![Number Dashbaord](/images/number_dashboard.png)
+![Number Dashboard](/images/number_dashboard.png)
   </Step>
 
   <Step title="Buy Number">
     View available numbers with pricing from different providers
-    ![Number Dashbaord](/images/buy_numbers.png)
+    ![Number Dashboard](/images/buy_numbers.png)
   </Step>
   <Step title="Use Numbers">
 Use the number 

--- a/telephony/plivo-integration.mdx
+++ b/telephony/plivo-integration.mdx
@@ -78,7 +78,7 @@ Now provider is added to your ringg workspace
 
 ![Provider Successfully Added](/images/provider_added.png)
 
-## Step 4: Use Plivo Number in Ringg Dashbaord 
+## Step 4: Use Plivo Number in Ringg Dashboard
 ## Number Management
 
 For comprehensive number management features, including:


### PR DESCRIPTION
## Summary

- Reworked the Ringg AI overview into role-based paths for backend/API engineers, web widget UI engineers, and dashboard/product users.
- Split the web widget guide into focused Mintlify pages for quickstart, configuration, events, chat widgets, and production QA/security.
- Simplified dashboard guides and key concepts for product/business users, and added beta large-campaign API docs for 5k+ row flows.
- Updated the OpenAPI spec and endpoint docs so individual outbound calls require exactly one of `from_number_id` or `from_number`.
- Added `AGENTS.md` with repo-specific Codex guidance so future docs changes preserve these product decisions.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('docs.json','utf8')); JSON.parse(require('fs').readFileSync('api-reference/openapi.json','utf8')); console.log('json ok')"`
- `git diff --check`
- `pnpm exec mint openapi-check api-reference/openapi.json`
- `pnpm exec mint broken-links`

## Notes

- Workflow contact-list APIs remain hidden until Workflows is live.
- New large-campaign endpoints are documented as beta and positioned for 5k+ row campaigns.
