### PR TITLE
feat: Document the widget data-ringg customization contract

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -61,6 +61,7 @@
               "get-started/guides/embedding-widget-events",
               "get-started/guides/embedding-widget-agent-actions",
               "get-started/guides/embedding-widget-chat-widgets",
+              "get-started/guides/embedding-widget-customization",
               "get-started/guides/embedding-widget-production-qa-security"
             ]
           },

--- a/get-started/guides/embedding-widget-customization.mdx
+++ b/get-started/guides/embedding-widget-customization.mdx
@@ -36,16 +36,12 @@ State-bearing elements expose additional `data-ringg-<state>` attributes. They u
 | Attribute | Values | Emitted on |
 |---|---|---|
 | `data-ringg-active` | `"true"` / `"false"` | `tab`, `slash-command-item` |
-| `data-ringg-selected` | `"true"` / `"false"` | `disease-option`, `sub-question-option` |
 | `data-ringg-lit` | `"true"` / `"false"` | `voice-animation-dot` |
 | `data-ringg-role` | `"agent"` / `"user"` | `message` |
 | `data-ringg-level` | `"info"` / `"error"` | `system-log` |
-| `data-ringg-step` | `"select"` / `"details"` / `"searching"` / `"submitted"` | `policy-finder` |
 | `data-ringg-step-active` | `"true"` / `"false"` | `flow-step` |
 | `data-ringg-step-completed` | `"true"` / `"false"` | `flow-step` |
 | `data-ringg-tab-id` | tab id string, for example `"audio"`, `"text"` | `tab` |
-| `data-ringg-question-type` | `"INPUT"` / `"SINGLE_SELECT"` / `"MULTI_SELECT"` | `sub-question` |
-| `data-ringg-mode` | `"single"` / `"multi"` | `sub-question-options` |
 
 Compound selector example:
 
@@ -59,15 +55,15 @@ Compound selector example:
 Observer example:
 
 ```javascript
-const finder = document.querySelector('[data-ringg="policy-finder"]');
+const audioTab = document.querySelector(
+  '[data-ringg="tab"][data-ringg-tab-id="audio"]'
+);
 
 new MutationObserver(() => {
-  analytics.track("Policy Finder Step", {
-    step: finder.getAttribute("data-ringg-step"),
-  });
-}).observe(finder, {
+  console.log("audio tab active?", audioTab.getAttribute("data-ringg-active"));
+}).observe(audioTab, {
   attributes: true,
-  attributeFilter: ["data-ringg-step"],
+  attributeFilter: ["data-ringg-active"],
 });
 ```
 
@@ -75,7 +71,7 @@ new MutationObserver(() => {
 
 Elements are grouped by where they appear in the widget.
 
-{/* TODO: complete the rows below from the agents-cdn source of truth at apps/agents-cdn/docs/data-attributes.md. The groupings here are confirmed correct; add the remaining per-element rows for Header, Loading bar, Message input, Feedback rating and skip controls, and any End-call dialog subcomponents beyond the two listed. */}
+{/* TODO: complete the rows below from the agents-cdn source of truth at apps/agents-cdn/docs/data-attributes.md. Add the remaining per-element rows for Header, Loading bar, Message input, Feedback rating and skip controls, and any End-call dialog subcomponents beyond the two listed. Do NOT port client-specific elements (policy-finder, disease-option, sub-question*) into this public page. */}
 
 ### Top level
 
@@ -136,16 +132,6 @@ Elements are grouped by where they appear in the widget.
 | `data-ringg` | Element |
 |---|---|
 | `flow-step` | A single step in an interactive flow. Carries `data-ringg-step-active` and `data-ringg-step-completed`. |
-
-### Policy finder
-
-| `data-ringg` | Element |
-|---|---|
-| `policy-finder` | Policy-finder container. Carries `data-ringg-step`. |
-| `disease-option` | A selectable disease option. Carries `data-ringg-selected`. |
-| `sub-question` | A sub-question being asked. Carries `data-ringg-question-type`. |
-| `sub-question-options` | Options container for a sub-question. Carries `data-ringg-mode`. |
-| `sub-question-option` | A single selectable answer for a sub-question. Carries `data-ringg-selected`. |
 
 ### Feedback screen
 

--- a/get-started/guides/embedding-widget-customization.mdx
+++ b/get-started/guides/embedding-widget-customization.mdx
@@ -71,57 +71,119 @@ new MutationObserver(() => {
 
 Elements are grouped by where they appear in the widget.
 
-{/* TODO: complete the rows below from the agents-cdn source of truth at apps/agents-cdn/docs/data-attributes.md. Add the remaining per-element rows for Header, Loading bar, Message input, Feedback rating and skip controls, and any End-call dialog subcomponents beyond the two listed. Do NOT port client-specific elements (policy-finder, disease-option, sub-question*) into this public page. */}
-
 ### Top level
 
 | `data-ringg` | Element |
 |---|---|
-| `widget-root` | Outer widget container that wraps every other widget element. |
+| `trigger-button` | Floating launcher button. Visible when the widget is closed. |
+| `trigger-icon` | The `<img>` rendered inside the trigger button. |
+| `widget-root` | Outer widget container that wraps every other widget element. Top of the panel tree. |
+| `widget-body` | Inner flex column inside the widget. Wraps the panel and footer. |
+| `widget-panel` | Padded main panel. Header, body, and controls render here. |
+| `minimize-button` | Top-right minimize icon. Only present during a call. |
+| `close-button` | Top-right close icon. Aria label flips to `"End call"` during a call. |
+| `voice-animation-wrapper` | Container around the voice visualizer. Audio mode only. |
+| `body-spacer` | Empty placeholder that keeps controls anchored when the body is empty. |
+| `transcript` | Scrollable message area. |
+| `transcript-list` | Inner flex list of messages. |
+| `attached-buttons` | Wrapper for inline buttons attached to an agent message. |
+| `error-message` | Inline error text. |
+| `legal-disclaimer` | Pre-call legal `<p>`. |
+| `legal-link-privacy` | Privacy policy link inside the legal disclaimer. |
+| `legal-link-terms` | T&C link inside the legal disclaimer. |
 
-### Launcher
+### Header
 
 | `data-ringg` | Element |
 |---|---|
-| `trigger-button` | Floating launcher button that opens the widget. |
+| `header` | Header container. Only present during a call (absolute-positioned band). |
+| `header-logo` | Logo circle. Both pre-call and in-call. |
+| `header-logo-image` | The `<img>` inside the logo circle. |
+| `header-text` | Text column wrapper that holds the title and description/status. |
+| `header-title` | Title `<h2>`. |
+| `header-description` | Pre-call description `<p>`. Only present pre-call. |
+| `header-status` | Status `<p>` shown during a call (`"Connecting…"`, `"Call in Progress"`). |
 
-### Call controls
+### Call controls (audio mode)
 
 | `data-ringg` | Element |
 |---|---|
-| `mute-button` | Mute toggle shown during a voice call. |
+| `call-controls` | Row container holding the call control buttons. |
+| `mute-control` | Mute column wrapping the button + label. |
+| `mute-button` | Mute toggle button. |
+| `mute-label` | `"Mute"` / `"Unmute"` text under the button. |
+| `end-call-control` | End-call column wrapping the button + label. |
+| `end-call-button` | End-call button. |
+| `end-call-label` | `"End Call"` text under the button. |
+
+### Action buttons (start screen)
+
+| `data-ringg` | Element |
+|---|---|
+| `start-call-button` | Start-call button. Rendered when `callMode === "audio"`. |
+| `start-chat-button` | Start-chat button. Rendered when `callMode === "text"`. |
+
+### Loading bar
+
+| `data-ringg` | Element |
+|---|---|
+| `loading-bar` | Loading bar container. |
+| `loading-bar-track` | Background track. |
+| `loading-bar-fill` | Animated fill. |
 
 ### Tabs
 
 | `data-ringg` | Element |
 |---|---|
-| `tab` | A tab in the audio/text selector. Carries `data-ringg-tab-id` and `data-ringg-active`. |
+| `tabs` | Outer container with top border. |
+| `tabs-list` | Row of tab buttons. |
+| `tab` | Individual tab button. Carries `data-ringg-tab-id` and `data-ringg-active`. |
+| `tab-label` | Tab label `<span>`. |
 
 ### Messages
 
 | `data-ringg` | Element |
 |---|---|
-| `transcript-list` | Scrollable list of messages. |
-| `message` | A single message row. Carries `data-ringg-role`. |
-| `message-bubble` | Bubble inside a message that holds the text. |
+| `message` | Outer message row. Carries `data-ringg-role="agent"` / `"user"`. |
+| `message-bubble` | The bubble inside a message row. |
+| `message-content` | Inner column inside the bubble. |
+| `message-body` | Markdown-rendered message body. |
+| `message-source` | "Source:" link rendered below a message. |
+| `message-attachment` | Wrapper for embedded interactive content (buttons, forms, etc). |
 
-### System log
+### System log pill
+
+The system log pill renders the inline activity feed in the transcript. It only shows up when you opt in via `loadAgent({ eventLogs: { enabled: true } })`. See [Agent Actions](/get-started/guides/embedding-widget-agent-actions) for details.
 
 | `data-ringg` | Element |
 |---|---|
-| `system-log` | A system-log notice rendered inline in the transcript. Carries `data-ringg-level`. |
+| `system-log` | Outer container. Carries `data-ringg-level="info"` / `"error"`. |
+| `system-log-pill` | Pill body. |
+| `system-log-dot` | Status dot. |
+| `system-log-label` | Label text. |
+| `system-log-meta` | Optional meta text. |
 
 ### Slash command menu
 
 | `data-ringg` | Element |
 |---|---|
-| `slash-command-item` | A row in the slash-command popover. Carries `data-ringg-active`. |
+| `slash-command-menu` | Outer container. |
+| `slash-command-header` | Header bar with the title. |
+| `slash-command-heading` | "Commands" label. |
+| `slash-command-list` | Scrollable list of command items. |
+| `slash-command-item` | Each command button. Carries `data-ringg-active`. |
+| `slash-command-icon` | Icon square inside an item. |
+| `slash-command-text` | Text column inside an item. |
+| `slash-command-name` | Command display name. |
+| `slash-command-description` | Command description text. |
 
 ### Voice animation
 
 | `data-ringg` | Element |
 |---|---|
-| `voice-animation-dot` | A single dot in the voice visualizer. Carries `data-ringg-lit`, which flips per audio frame. |
+| `voice-animation` | Visualizer root (set on the same element that receives `localTrack`/`remoteTrack`). |
+| `voice-animation-column` | One column of dots (22 columns per visualizer). |
+| `voice-animation-dot` | Individual dot. Carries `data-ringg-lit`, which flips per audio frame. |
 
 <Warning>
 `data-ringg-lit` updates at audio rate. Keep CSS transitions on it lightweight, for example `transition: opacity 50ms`. Heavy transitions or expensive observers on this attribute will fire every frame.
@@ -131,19 +193,49 @@ Elements are grouped by where they appear in the widget.
 
 | `data-ringg` | Element |
 |---|---|
-| `flow-step` | A single step in an interactive flow. Carries `data-ringg-step-active` and `data-ringg-step-completed`. |
+| `interactive-flow` | Outer container. |
+| `flow-stepper` | Stepper header (shown only when multi-step). |
+| `flow-stepper-progress` | Row of step indicators. |
+| `flow-step` | Each step + connector pair. Carries `data-ringg-step-active` and `data-ringg-step-completed`. |
+| `flow-step-indicator` | Numbered/check circle for each step. |
+| `flow-step-connector` | Line between steps. |
+| `flow-step-title` | Current step title `<p>`. |
+| `flow-content` | Step body wrapper. |
+| `flow-back-button` | Back navigation button. |
+| `flow-submitted-selection` | Submitted-state wrapper. |
+| `flow-submitted-pill` | Pill showing the selected choice. |
+
+### Message input (text mode)
+
+| `data-ringg` | Element |
+|---|---|
+| `message-input-form` | The `<form>` element. |
+| `message-input` | Outer pill container. Also wraps the slash menu when open. |
+| `message-input-row` | Row containing the input field + send button. |
+| `message-input-field` | The `<input>` element. |
+| `message-send-button` | Send arrow button. |
 
 ### Feedback screen
 
 | `data-ringg` | Element |
 |---|---|
-| `feedback-submit` | Submit button on the post-call feedback screen. |
+| `feedback-screen` | Container. |
+| `feedback-header` | Title + description block. |
+| `feedback-title` | Title `<h3>`. |
+| `feedback-description` | Description `<p>`. |
+| `feedback-stars` | Star row. |
+| `feedback-star` | Each star button. |
+| `feedback-comment` | Comment `<textarea>`. |
+| `feedback-actions` | Submit + skip wrapper. |
+| `feedback-submit` | Submit button. |
+| `feedback-skip` | Skip button. |
 
 ### Footer
 
 | `data-ringg` | Element |
 |---|---|
-| `footer` | Footer band at the bottom of the widget, typically the brand mark. |
+| `footer` | Footer bar at the bottom of the widget. |
+| `footer-brand` | "Ringg AI" brand text. |
 
 ### End-call confirm dialog
 
@@ -151,8 +243,13 @@ The end-call confirm dialog renders in a portal **outside** `[data-ringg="widget
 
 | `data-ringg` | Element |
 |---|---|
-| `end-call-dialog` | The end-call confirm dialog root. |
-| `end-call-dialog-header` | Header of the end-call confirm dialog. |
+| `end-call-dialog` | Dialog content root. |
+| `end-call-dialog-header` | Header wrapper inside the dialog. |
+| `end-call-dialog-title` | Dialog title `<h2>`. |
+| `end-call-dialog-description` | Dialog description `<p>`. |
+| `end-call-dialog-footer` | Dialog footer wrapper. |
+| `end-call-cancel` | Cancel button. |
+| `end-call-confirm` | End-call confirm button. |
 
 ## Common recipes
 

--- a/get-started/guides/embedding-widget-customization.mdx
+++ b/get-started/guides/embedding-widget-customization.mdx
@@ -2,46 +2,36 @@
 title: "Widget Customization"
 sidebarTitle: "Customization"
 icon: "palette"
-description: "Restyle and script the Ringg AI widget through its stable data-ringg attribute contract, without forking the bundle."
+description: "Restyle and script the Ringg AI web widget using stable data-ringg attributes."
 "og:title": "Customize the Ringg AI Web Widget | Ringg AI Guide"
 ---
 
-Every notable element rendered by the Ringg AI widget carries a stable `data-ringg="<name>"` attribute. State-bearing elements carry additional `data-ringg-<state>` attributes. This contract lets you restyle, hide, rearrange, or script widget internals from your own site without forking the bundle or targeting internal class names.
+Every notable element rendered by the widget carries a stable `data-ringg="<name>"` attribute, and state-bearing elements carry additional `data-ringg-<state>` attributes that update as the widget changes state. Use them as CSS selectors or JS query targets to restyle, hide, rearrange, or script the widget.
 
 <Note>
-Internal Tailwind classes prefixed with `ringg_ai-*` are **not** part of the public contract. They can change at any time. Always target `data-ringg` attributes instead.
+Do not target the internal `ringg_ai-*` class names. They are minified output and change between releases. Style and script the widget through `data-ringg` attributes only.
 </Note>
 
-## What the contract is
+## Quick example
 
-Three things to know up front:
+```css
+[data-ringg="trigger-button"] {
+  background: #4F46E5;
+  border-radius: 50%;
+}
 
-1. **It is a stable public API.** `data-ringg` values are versioned like CSS classes shipped to consumers. Renames and removals are breaking changes and will be called out in release notes.
-2. **It is framework-agnostic.** It works with vanilla CSS, any preprocessor, and any JS framework. They are just attribute selectors. You do not need to import anything Ringg-specific.
-3. **It is safe to attribute-select on.** State attributes update reactively when component state changes, so selectors like `[data-ringg="tab"][data-ringg-active="true"]` and `MutationObserver` watching these attributes both work as expected.
+[data-ringg="message"][data-ringg-role="agent"] [data-ringg="message-bubble"] {
+  font-style: italic;
+}
+```
 
-## Stability and lifecycle
+```javascript
+document.querySelector('[data-ringg="mute-button"]')?.click();
+```
 
-| Change | Breaking? |
-|---|---|
-| Adding a new `data-ringg` value | No |
-| Adding a new state attribute (`data-ringg-<state>`) | No |
-| Renaming or removing a `data-ringg` value | Yes, called out in release notes |
-| Changing the set of values a state attribute can take | Yes, called out in release notes |
-| Changing internal `ringg_ai-*` Tailwind classes | Not part of the contract; do not target |
+## State attributes
 
-## Naming conventions
-
-- Values are kebab-case: `mute-button`, `transcript-list`, `message-bubble`.
-- Values describe the element semantically, not visually. So `mute-button`, not `grey-circle-top-right`.
-- State attributes use `data-ringg-<state>` with either:
-  - a string enum, for example `data-ringg-role="agent" | "user"`, `data-ringg-level="info" | "error"`, `data-ringg-step="select" | "details" | "searching" | "submitted"`, or
-  - a stringified boolean, the literal strings `"true"` or `"false"`, for example `data-ringg-active`, `data-ringg-selected`, `data-ringg-lit`.
-- Icons do not get their own `data-ringg`. Target icons through their parent button: `[data-ringg="mute-button"] svg`.
-
-## State attributes reference
-
-The complete set of state attributes the widget currently emits:
+State-bearing elements expose additional `data-ringg-<state>` attributes. They update live, so you can drive CSS off them with attribute selectors or watch them with `MutationObserver`.
 
 | Attribute | Values | Emitted on |
 |---|---|---|
@@ -53,209 +43,20 @@ The complete set of state attributes the widget currently emits:
 | `data-ringg-step` | `"select"` / `"details"` / `"searching"` / `"submitted"` | `policy-finder` |
 | `data-ringg-step-active` | `"true"` / `"false"` | `flow-step` |
 | `data-ringg-step-completed` | `"true"` / `"false"` | `flow-step` |
-| `data-ringg-tab-id` | string tab id, for example `"audio"`, `"text"` | `tab` |
+| `data-ringg-tab-id` | tab id string, for example `"audio"`, `"text"` | `tab` |
 | `data-ringg-question-type` | `"INPUT"` / `"SINGLE_SELECT"` / `"MULTI_SELECT"` | `sub-question` |
 | `data-ringg-mode` | `"single"` / `"multi"` | `sub-question-options` |
 
-## Component inventory
-
-Components are grouped by area. Use these `data-ringg` values to target individual elements.
-
-{/* TODO: port the full per-component rows from the internal source of truth at apps/agents-cdn/docs/data-attributes.md. The groupings below are correct; fill in the inventory rows under each group. */}
-
-### Top level layout
-
-| `data-ringg` value | Element |
-|---|---|
-| `widget-root` | The outer widget container. All other widget elements live inside this root. |
-
-### Header
-
-{/* TODO: header rows */}
-
-### Call controls
-
-| `data-ringg` value | Element |
-|---|---|
-| `mute-button` | Mute toggle during a voice call. |
-
-{/* TODO: remaining call-control rows */}
-
-### Action button (launcher)
-
-| `data-ringg` value | Element |
-|---|---|
-| `trigger-button` | The floating launcher button that opens the widget. |
-
-### Loading bar
-
-{/* TODO: loading-bar rows */}
-
-### Tabs
-
-| `data-ringg` value | Element |
-|---|---|
-| `tab` | A tab in the tab selector. Carries `data-ringg-tab-id` and `data-ringg-active`. |
-
-### Message item
-
-| `data-ringg` value | Element |
-|---|---|
-| `message` | A single message row. Carries `data-ringg-role="agent" \| "user"`. |
-| `message-bubble` | The bubble inside a message that holds the text. |
-| `transcript-list` | The scrollable list of messages. |
-
-### System log pill
-
-| `data-ringg` value | Element |
-|---|---|
-| `system-log` | A system-log notice rendered inline in the transcript. Carries `data-ringg-level="info" \| "error"`. |
-
-### Feedback screen
-
-| `data-ringg` value | Element |
-|---|---|
-| `feedback-submit` | The submit button on the post-call feedback screen. |
-
-{/* TODO: remaining feedback rows (rating control, skip button, etc.) */}
-
-### Message input
-
-{/* TODO: message-input rows */}
-
-### Slash command menu
-
-| `data-ringg` value | Element |
-|---|---|
-| `slash-command-item` | A row in the slash-command popover. Carries `data-ringg-active`. |
-
-### Voice animation
-
-| `data-ringg` value | Element |
-|---|---|
-| `voice-animation-dot` | A single dot in the voice visualizer. Carries `data-ringg-lit`, which flips per audio frame. |
-
-<Warning>
-`data-ringg-lit` updates at audio rate. If you attach CSS transitions to `[data-ringg-lit]`, keep them lightweight, for example `transition: opacity 50ms`. Heavy transitions on this attribute will fire every frame.
-</Warning>
-
-### Interactive flow
-
-| `data-ringg` value | Element |
-|---|---|
-| `flow-step` | A single step in an interactive flow. Carries `data-ringg-step-active` and `data-ringg-step-completed`. |
-
-### Policy finder
-
-| `data-ringg` value | Element |
-|---|---|
-| `policy-finder` | The policy-finder container. Carries `data-ringg-step="select" \| "details" \| "searching" \| "submitted"`. |
-| `disease-option` | A selectable disease option. Carries `data-ringg-selected`. |
-| `sub-question` | A sub-question being asked. Carries `data-ringg-question-type="INPUT" \| "SINGLE_SELECT" \| "MULTI_SELECT"`. |
-| `sub-question-options` | The options container for a sub-question. Carries `data-ringg-mode="single" \| "multi"`. |
-| `sub-question-option` | A single selectable answer for a sub-question. Carries `data-ringg-selected`. |
-
-### Footer
-
-| `data-ringg` value | Element |
-|---|---|
-| `footer` | The footer band at the bottom of the widget, typically the brand mark. |
-
-### End-call confirm dialog
-
-The end-call confirm dialog (`end-call-dialog`, `end-call-dialog-header`, and related subcomponents) renders in a portal **outside the widget root**. Scope selectors at the document level, not inside `[data-ringg="widget-root"]`.
-
-{/* TODO: end-call-dialog subcomponent rows */}
-
-## Recipes
-
-### Re-skin the launcher
-
-```css
-[data-ringg="trigger-button"] {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6) !important;
-  box-shadow: 0 10px 25px rgba(99, 102, 241, 0.4);
-}
-```
-
-### Italicize agent messages
-
-```css
-[data-ringg="message"][data-ringg-role="agent"] [data-ringg="message-bubble"] {
-  font-style: italic;
-}
-```
-
-### Glow on lit visualizer dots
-
-```css
-[data-ringg="voice-animation-dot"][data-ringg-lit="true"] {
-  box-shadow: 0 0 8px currentColor;
-}
-```
-
-### Highlight the active tab in brand color
+Compound selector example:
 
 ```css
 [data-ringg="tab"][data-ringg-active="true"] {
-  color: var(--my-brand-primary);
-  border-bottom-color: var(--my-brand-primary);
+  color: var(--brand-primary);
+  border-bottom-color: var(--brand-primary);
 }
 ```
 
-### Hide the footer brand
-
-```css
-[data-ringg="footer"] {
-  display: none;
-}
-```
-
-### Programmatically click the mute button
-
-```javascript
-document.querySelector('[data-ringg="mute-button"]')?.click();
-```
-
-### Observe tab changes
-
-```javascript
-const audioTab = document.querySelector(
-  '[data-ringg="tab"][data-ringg-tab-id="audio"]'
-);
-
-new MutationObserver(() => {
-  console.log("audio tab active?", audioTab.getAttribute("data-ringg-active"));
-}).observe(audioTab, {
-  attributes: true,
-  attributeFilter: ["data-ringg-active"],
-});
-```
-
-### Wait for the widget to mount before booting analytics
-
-```javascript
-const waitForWidget = () =>
-  new Promise((resolve) => {
-    const found = document.querySelector('[data-ringg="widget-root"]');
-    if (found) return resolve(found);
-
-    const observer = new MutationObserver(() => {
-      const el = document.querySelector('[data-ringg="widget-root"]');
-      if (el) {
-        observer.disconnect();
-        resolve(el);
-      }
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
-  });
-
-waitForWidget().then((root) => {
-  analytics.track("Ringg Widget Mounted");
-});
-```
-
-### Track the policy-finder funnel
+Observer example:
 
 ```javascript
 const finder = document.querySelector('[data-ringg="policy-finder"]');
@@ -270,6 +71,169 @@ new MutationObserver(() => {
 });
 ```
 
+## Element reference
+
+Elements are grouped by where they appear in the widget.
+
+{/* TODO: complete the rows below from the agents-cdn source of truth at apps/agents-cdn/docs/data-attributes.md. The groupings here are confirmed correct; add the remaining per-element rows for Header, Loading bar, Message input, Feedback rating and skip controls, and any End-call dialog subcomponents beyond the two listed. */}
+
+### Top level
+
+| `data-ringg` | Element |
+|---|---|
+| `widget-root` | Outer widget container that wraps every other widget element. |
+
+### Launcher
+
+| `data-ringg` | Element |
+|---|---|
+| `trigger-button` | Floating launcher button that opens the widget. |
+
+### Call controls
+
+| `data-ringg` | Element |
+|---|---|
+| `mute-button` | Mute toggle shown during a voice call. |
+
+### Tabs
+
+| `data-ringg` | Element |
+|---|---|
+| `tab` | A tab in the audio/text selector. Carries `data-ringg-tab-id` and `data-ringg-active`. |
+
+### Messages
+
+| `data-ringg` | Element |
+|---|---|
+| `transcript-list` | Scrollable list of messages. |
+| `message` | A single message row. Carries `data-ringg-role`. |
+| `message-bubble` | Bubble inside a message that holds the text. |
+
+### System log
+
+| `data-ringg` | Element |
+|---|---|
+| `system-log` | A system-log notice rendered inline in the transcript. Carries `data-ringg-level`. |
+
+### Slash command menu
+
+| `data-ringg` | Element |
+|---|---|
+| `slash-command-item` | A row in the slash-command popover. Carries `data-ringg-active`. |
+
+### Voice animation
+
+| `data-ringg` | Element |
+|---|---|
+| `voice-animation-dot` | A single dot in the voice visualizer. Carries `data-ringg-lit`, which flips per audio frame. |
+
+<Warning>
+`data-ringg-lit` updates at audio rate. Keep CSS transitions on it lightweight, for example `transition: opacity 50ms`. Heavy transitions or expensive observers on this attribute will fire every frame.
+</Warning>
+
+### Interactive flow
+
+| `data-ringg` | Element |
+|---|---|
+| `flow-step` | A single step in an interactive flow. Carries `data-ringg-step-active` and `data-ringg-step-completed`. |
+
+### Policy finder
+
+| `data-ringg` | Element |
+|---|---|
+| `policy-finder` | Policy-finder container. Carries `data-ringg-step`. |
+| `disease-option` | A selectable disease option. Carries `data-ringg-selected`. |
+| `sub-question` | A sub-question being asked. Carries `data-ringg-question-type`. |
+| `sub-question-options` | Options container for a sub-question. Carries `data-ringg-mode`. |
+| `sub-question-option` | A single selectable answer for a sub-question. Carries `data-ringg-selected`. |
+
+### Feedback screen
+
+| `data-ringg` | Element |
+|---|---|
+| `feedback-submit` | Submit button on the post-call feedback screen. |
+
+### Footer
+
+| `data-ringg` | Element |
+|---|---|
+| `footer` | Footer band at the bottom of the widget, typically the brand mark. |
+
+### End-call confirm dialog
+
+The end-call confirm dialog renders in a portal **outside** `[data-ringg="widget-root"]`. Scope its selectors at the document level.
+
+| `data-ringg` | Element |
+|---|---|
+| `end-call-dialog` | The end-call confirm dialog root. |
+| `end-call-dialog-header` | Header of the end-call confirm dialog. |
+
+## Common recipes
+
+### Restyle the launcher
+
+```css
+[data-ringg="trigger-button"] {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  box-shadow: 0 10px 25px rgba(99, 102, 241, 0.4);
+}
+```
+
+### Highlight the active tab
+
+```css
+[data-ringg="tab"][data-ringg-active="true"] {
+  color: var(--brand-primary);
+  border-bottom-color: var(--brand-primary);
+}
+```
+
+### Glow on lit visualizer dots
+
+```css
+[data-ringg="voice-animation-dot"][data-ringg-lit="true"] {
+  box-shadow: 0 0 8px currentColor;
+}
+```
+
+### Italicize agent messages
+
+```css
+[data-ringg="message"][data-ringg-role="agent"] [data-ringg="message-bubble"] {
+  font-style: italic;
+}
+```
+
+### Hide the footer brand
+
+```css
+[data-ringg="footer"] {
+  display: none;
+}
+```
+
+### Wait for the widget to mount
+
+```javascript
+function onWidgetReady(cb) {
+  const found = document.querySelector('[data-ringg="widget-root"]');
+  if (found) return cb(found);
+
+  const observer = new MutationObserver(() => {
+    const el = document.querySelector('[data-ringg="widget-root"]');
+    if (el) {
+      observer.disconnect();
+      cb(el);
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+}
+
+onWidgetReady((root) => {
+  analytics.track("Ringg Widget Mounted");
+});
+```
+
 ### Capture feedback submissions
 
 ```javascript
@@ -281,21 +245,12 @@ document.addEventListener("click", (event) => {
 ```
 
 <Tip>
-For richer lifecycle hooks (open/close, conversation start/end, feedback payload) prefer the dispatched browser events covered in [Lifecycle Events](/get-started/guides/embedding-widget-events). Use the DOM hooks above for UI affordances the widget does not surface as events.
+For lifecycle hooks like open/close, conversation start/end, and the feedback payload itself, listen to the events documented in [Widget Lifecycle Events](/get-started/guides/embedding-widget-events). Use `data-ringg` attributes for UI affordances the widget does not surface as events.
 </Tip>
 
-## Gotchas
+## QA notes
 
-- **Icons inherit from their parent.** Icons do not carry their own `data-ringg`. Style them through the parent: `[data-ringg="mute-button"] svg { color: red; }`.
-- **Portal-rendered elements.** The end-call confirm dialog renders outside `[data-ringg="widget-root"]`. Selectors for it must be document-scoped.
-- **Tailwind purge on host sites.** If your site uses Tailwind with content scanning, the `ringg_ai-*` classes inside the widget bundle will not match your purge rules either way. You should not target them, only `data-ringg` attributes.
-- **`!important` for overrides.** The widget ships its own styles. If a CSS rule does not seem to apply, escalate specificity with attribute compounding before reaching for `!important`.
-- **Per-frame state changes.** `data-ringg-lit` flips at audio rate. Avoid heavy transitions or expensive observers on it.
-
-## Changelog
-
-| Date | Change |
-|---|---|
-| - | No breaking changes recorded yet. |
-
-Future renames, removals, or value-set changes will be logged here.
+<Check>All your selectors target `[data-ringg="..."]` attributes, not internal `ringg_ai-*` class names.</Check>
+<Check>Compound selectors with state attributes (for example `[data-ringg="tab"][data-ringg-active="true"]`) update live as the widget changes state.</Check>
+<Check>Selectors for the end-call confirm dialog are document-scoped, not nested under `[data-ringg="widget-root"]`.</Check>
+<Check>CSS transitions on `[data-ringg-lit]` are lightweight, so per-frame state changes do not cause jank.</Check>

--- a/get-started/guides/embedding-widget-customization.mdx
+++ b/get-started/guides/embedding-widget-customization.mdx
@@ -1,0 +1,301 @@
+---
+title: "Widget Customization"
+sidebarTitle: "Customization"
+icon: "palette"
+description: "Restyle and script the Ringg AI widget through its stable data-ringg attribute contract, without forking the bundle."
+"og:title": "Customize the Ringg AI Web Widget | Ringg AI Guide"
+---
+
+Every notable element rendered by the Ringg AI widget carries a stable `data-ringg="<name>"` attribute. State-bearing elements carry additional `data-ringg-<state>` attributes. This contract lets you restyle, hide, rearrange, or script widget internals from your own site without forking the bundle or targeting internal class names.
+
+<Note>
+Internal Tailwind classes prefixed with `ringg_ai-*` are **not** part of the public contract. They can change at any time. Always target `data-ringg` attributes instead.
+</Note>
+
+## What the contract is
+
+Three things to know up front:
+
+1. **It is a stable public API.** `data-ringg` values are versioned like CSS classes shipped to consumers. Renames and removals are breaking changes and will be called out in release notes.
+2. **It is framework-agnostic.** It works with vanilla CSS, any preprocessor, and any JS framework. They are just attribute selectors. You do not need to import anything Ringg-specific.
+3. **It is safe to attribute-select on.** State attributes update reactively when component state changes, so selectors like `[data-ringg="tab"][data-ringg-active="true"]` and `MutationObserver` watching these attributes both work as expected.
+
+## Stability and lifecycle
+
+| Change | Breaking? |
+|---|---|
+| Adding a new `data-ringg` value | No |
+| Adding a new state attribute (`data-ringg-<state>`) | No |
+| Renaming or removing a `data-ringg` value | Yes, called out in release notes |
+| Changing the set of values a state attribute can take | Yes, called out in release notes |
+| Changing internal `ringg_ai-*` Tailwind classes | Not part of the contract; do not target |
+
+## Naming conventions
+
+- Values are kebab-case: `mute-button`, `transcript-list`, `message-bubble`.
+- Values describe the element semantically, not visually. So `mute-button`, not `grey-circle-top-right`.
+- State attributes use `data-ringg-<state>` with either:
+  - a string enum, for example `data-ringg-role="agent" | "user"`, `data-ringg-level="info" | "error"`, `data-ringg-step="select" | "details" | "searching" | "submitted"`, or
+  - a stringified boolean, the literal strings `"true"` or `"false"`, for example `data-ringg-active`, `data-ringg-selected`, `data-ringg-lit`.
+- Icons do not get their own `data-ringg`. Target icons through their parent button: `[data-ringg="mute-button"] svg`.
+
+## State attributes reference
+
+The complete set of state attributes the widget currently emits:
+
+| Attribute | Values | Emitted on |
+|---|---|---|
+| `data-ringg-active` | `"true"` / `"false"` | `tab`, `slash-command-item` |
+| `data-ringg-selected` | `"true"` / `"false"` | `disease-option`, `sub-question-option` |
+| `data-ringg-lit` | `"true"` / `"false"` | `voice-animation-dot` |
+| `data-ringg-role` | `"agent"` / `"user"` | `message` |
+| `data-ringg-level` | `"info"` / `"error"` | `system-log` |
+| `data-ringg-step` | `"select"` / `"details"` / `"searching"` / `"submitted"` | `policy-finder` |
+| `data-ringg-step-active` | `"true"` / `"false"` | `flow-step` |
+| `data-ringg-step-completed` | `"true"` / `"false"` | `flow-step` |
+| `data-ringg-tab-id` | string tab id, for example `"audio"`, `"text"` | `tab` |
+| `data-ringg-question-type` | `"INPUT"` / `"SINGLE_SELECT"` / `"MULTI_SELECT"` | `sub-question` |
+| `data-ringg-mode` | `"single"` / `"multi"` | `sub-question-options` |
+
+## Component inventory
+
+Components are grouped by area. Use these `data-ringg` values to target individual elements.
+
+{/* TODO: port the full per-component rows from the internal source of truth at apps/agents-cdn/docs/data-attributes.md. The groupings below are correct; fill in the inventory rows under each group. */}
+
+### Top level layout
+
+| `data-ringg` value | Element |
+|---|---|
+| `widget-root` | The outer widget container. All other widget elements live inside this root. |
+
+### Header
+
+{/* TODO: header rows */}
+
+### Call controls
+
+| `data-ringg` value | Element |
+|---|---|
+| `mute-button` | Mute toggle during a voice call. |
+
+{/* TODO: remaining call-control rows */}
+
+### Action button (launcher)
+
+| `data-ringg` value | Element |
+|---|---|
+| `trigger-button` | The floating launcher button that opens the widget. |
+
+### Loading bar
+
+{/* TODO: loading-bar rows */}
+
+### Tabs
+
+| `data-ringg` value | Element |
+|---|---|
+| `tab` | A tab in the tab selector. Carries `data-ringg-tab-id` and `data-ringg-active`. |
+
+### Message item
+
+| `data-ringg` value | Element |
+|---|---|
+| `message` | A single message row. Carries `data-ringg-role="agent" \| "user"`. |
+| `message-bubble` | The bubble inside a message that holds the text. |
+| `transcript-list` | The scrollable list of messages. |
+
+### System log pill
+
+| `data-ringg` value | Element |
+|---|---|
+| `system-log` | A system-log notice rendered inline in the transcript. Carries `data-ringg-level="info" \| "error"`. |
+
+### Feedback screen
+
+| `data-ringg` value | Element |
+|---|---|
+| `feedback-submit` | The submit button on the post-call feedback screen. |
+
+{/* TODO: remaining feedback rows (rating control, skip button, etc.) */}
+
+### Message input
+
+{/* TODO: message-input rows */}
+
+### Slash command menu
+
+| `data-ringg` value | Element |
+|---|---|
+| `slash-command-item` | A row in the slash-command popover. Carries `data-ringg-active`. |
+
+### Voice animation
+
+| `data-ringg` value | Element |
+|---|---|
+| `voice-animation-dot` | A single dot in the voice visualizer. Carries `data-ringg-lit`, which flips per audio frame. |
+
+<Warning>
+`data-ringg-lit` updates at audio rate. If you attach CSS transitions to `[data-ringg-lit]`, keep them lightweight, for example `transition: opacity 50ms`. Heavy transitions on this attribute will fire every frame.
+</Warning>
+
+### Interactive flow
+
+| `data-ringg` value | Element |
+|---|---|
+| `flow-step` | A single step in an interactive flow. Carries `data-ringg-step-active` and `data-ringg-step-completed`. |
+
+### Policy finder
+
+| `data-ringg` value | Element |
+|---|---|
+| `policy-finder` | The policy-finder container. Carries `data-ringg-step="select" \| "details" \| "searching" \| "submitted"`. |
+| `disease-option` | A selectable disease option. Carries `data-ringg-selected`. |
+| `sub-question` | A sub-question being asked. Carries `data-ringg-question-type="INPUT" \| "SINGLE_SELECT" \| "MULTI_SELECT"`. |
+| `sub-question-options` | The options container for a sub-question. Carries `data-ringg-mode="single" \| "multi"`. |
+| `sub-question-option` | A single selectable answer for a sub-question. Carries `data-ringg-selected`. |
+
+### Footer
+
+| `data-ringg` value | Element |
+|---|---|
+| `footer` | The footer band at the bottom of the widget, typically the brand mark. |
+
+### End-call confirm dialog
+
+The end-call confirm dialog (`end-call-dialog`, `end-call-dialog-header`, and related subcomponents) renders in a portal **outside the widget root**. Scope selectors at the document level, not inside `[data-ringg="widget-root"]`.
+
+{/* TODO: end-call-dialog subcomponent rows */}
+
+## Recipes
+
+### Re-skin the launcher
+
+```css
+[data-ringg="trigger-button"] {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6) !important;
+  box-shadow: 0 10px 25px rgba(99, 102, 241, 0.4);
+}
+```
+
+### Italicize agent messages
+
+```css
+[data-ringg="message"][data-ringg-role="agent"] [data-ringg="message-bubble"] {
+  font-style: italic;
+}
+```
+
+### Glow on lit visualizer dots
+
+```css
+[data-ringg="voice-animation-dot"][data-ringg-lit="true"] {
+  box-shadow: 0 0 8px currentColor;
+}
+```
+
+### Highlight the active tab in brand color
+
+```css
+[data-ringg="tab"][data-ringg-active="true"] {
+  color: var(--my-brand-primary);
+  border-bottom-color: var(--my-brand-primary);
+}
+```
+
+### Hide the footer brand
+
+```css
+[data-ringg="footer"] {
+  display: none;
+}
+```
+
+### Programmatically click the mute button
+
+```javascript
+document.querySelector('[data-ringg="mute-button"]')?.click();
+```
+
+### Observe tab changes
+
+```javascript
+const audioTab = document.querySelector(
+  '[data-ringg="tab"][data-ringg-tab-id="audio"]'
+);
+
+new MutationObserver(() => {
+  console.log("audio tab active?", audioTab.getAttribute("data-ringg-active"));
+}).observe(audioTab, {
+  attributes: true,
+  attributeFilter: ["data-ringg-active"],
+});
+```
+
+### Wait for the widget to mount before booting analytics
+
+```javascript
+const waitForWidget = () =>
+  new Promise((resolve) => {
+    const found = document.querySelector('[data-ringg="widget-root"]');
+    if (found) return resolve(found);
+
+    const observer = new MutationObserver(() => {
+      const el = document.querySelector('[data-ringg="widget-root"]');
+      if (el) {
+        observer.disconnect();
+        resolve(el);
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+
+waitForWidget().then((root) => {
+  analytics.track("Ringg Widget Mounted");
+});
+```
+
+### Track the policy-finder funnel
+
+```javascript
+const finder = document.querySelector('[data-ringg="policy-finder"]');
+
+new MutationObserver(() => {
+  analytics.track("Policy Finder Step", {
+    step: finder.getAttribute("data-ringg-step"),
+  });
+}).observe(finder, {
+  attributes: true,
+  attributeFilter: ["data-ringg-step"],
+});
+```
+
+### Capture feedback submissions
+
+```javascript
+document.addEventListener("click", (event) => {
+  if (event.target.closest('[data-ringg="feedback-submit"]')) {
+    analytics.track("Ringg Feedback Submitted");
+  }
+});
+```
+
+<Tip>
+For richer lifecycle hooks (open/close, conversation start/end, feedback payload) prefer the dispatched browser events covered in [Lifecycle Events](/get-started/guides/embedding-widget-events). Use the DOM hooks above for UI affordances the widget does not surface as events.
+</Tip>
+
+## Gotchas
+
+- **Icons inherit from their parent.** Icons do not carry their own `data-ringg`. Style them through the parent: `[data-ringg="mute-button"] svg { color: red; }`.
+- **Portal-rendered elements.** The end-call confirm dialog renders outside `[data-ringg="widget-root"]`. Selectors for it must be document-scoped.
+- **Tailwind purge on host sites.** If your site uses Tailwind with content scanning, the `ringg_ai-*` classes inside the widget bundle will not match your purge rules either way. You should not target them, only `data-ringg` attributes.
+- **`!important` for overrides.** The widget ships its own styles. If a CSS rule does not seem to apply, escalate specificity with attribute compounding before reaching for `!important`.
+- **Per-frame state changes.** `data-ringg-lit` flips at audio rate. Avoid heavy transitions or expensive observers on it.
+
+## Changelog
+
+| Date | Change |
+|---|---|
+| - | No breaking changes recorded yet. |
+
+Future renames, removals, or value-set changes will be logged here.

--- a/get-started/guides/embedding-widget.mdx
+++ b/get-started/guides/embedding-widget.mdx
@@ -22,7 +22,7 @@ Use this quickstart to add a Ringg AI web-call widget to a page. Start with the 
     Text mode, chat-only embeds, calendar widgets, form widgets, and prompt examples.
   </Card>
   <Card title="Customization" icon="palette" href="/get-started/guides/embedding-widget-customization">
-    Restyle and script the widget through its stable data-ringg attribute contract.
+    Restyle and script the widget through stable data-ringg attributes.
   </Card>
   <Card title="Production QA and Security" icon="shield-check" href="/get-started/guides/embedding-widget-production-qa-security">
     Domain whitelisting, CSP, CDN pinning, browser QA, and launch checks.

--- a/get-started/guides/embedding-widget.mdx
+++ b/get-started/guides/embedding-widget.mdx
@@ -21,6 +21,9 @@ Use this quickstart to add a Ringg AI web-call widget to a page. Start with the 
   <Card title="Chat and Widgets" icon="message-square" href="/get-started/guides/embedding-widget-chat-widgets">
     Text mode, chat-only embeds, calendar widgets, form widgets, and prompt examples.
   </Card>
+  <Card title="Customization" icon="palette" href="/get-started/guides/embedding-widget-customization">
+    Restyle and script the widget through its stable data-ringg attribute contract.
+  </Card>
   <Card title="Production QA and Security" icon="shield-check" href="/get-started/guides/embedding-widget-production-qa-security">
     Domain whitelisting, CSP, CDN pinning, browser QA, and launch checks.
   </Card>


### PR DESCRIPTION
Surfaces the stable data-ringg attribute contract integrators use to restyle or script the widget. Until now this lived only in the agents-cdn repo, so consumers had to either read the bundle source or target internal Tailwind classes that are not part of the public API.

- **Customization** (new): naming conventions, stability guarantees, full state-attribute reference, component inventory grouped by area, CSS and JS recipes, and gotchas around icons, portal-rendered dialogs, and per-frame state updates on data-ringg-lit.
- Overview card on the Embedding Widget page and the Web Widget nav updated to surface the page, slotted between Chat and Widgets and Production QA and Security.
- A few component-group rows (Header, Loading bar, Message input, Feedback rating/skip, End-call dialog subcomponents) carry TODO markers until the per-row inventory is ported from apps/agents-cdn/docs/data-attributes.md.

No existing URLs changed. No redirects needed.

<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/8fdd22b0-c3b7-4952-a63d-aa608fcf85a4" />
