### PR TITLE
docs(widget): document es vs umd bundle choice

### DIFF
--- a/get-started/guides/embedding-widget-configuration.mdx
+++ b/get-started/guides/embedding-widget-configuration.mdx
@@ -9,29 +9,62 @@ This page covers the frontend configuration object passed to `loadAgent`. Config
 
 ## CDN loader
 
-The widget script exposes `loadAgent` after the CDN bundle finishes loading.
+The widget script exposes `loadAgent` after the CDN bundle finishes loading. Two builds are published: pick the one that matches how your host page loads JavaScript.
 
-```html
-<script>
-  function loadAgentsCdn(version, done) {
-    const stylesheet = document.createElement("link");
-    stylesheet.rel = "stylesheet";
-    stylesheet.type = "text/css";
-    stylesheet.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/style.css`;
+| Bundle | When to use |
+|---|---|
+| `dv-agent.es.js` | Module-aware setups: Vite, webpack, Next, or anything loaded inside `<script type="module">`. |
+| `dv-agent.umd.js` | jQuery pages, legacy CMS themes, and any host page that loads scripts with a plain `<script>` tag. |
 
-    const script = document.createElement("script");
-    script.type = "text/javascript";
-    script.onload = done;
-    script.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/dv-agent.es.js`;
+<Warning>
+The ES bundle is only safe inside module-aware setups. Loading `dv-agent.es.js` as a plain `<script>` leaks internals onto `window` and can clobber globals like jQuery's `$`, which breaks the host page. Use `dv-agent.umd.js` on any non-module page.
+</Warning>
 
-    document.head.appendChild(stylesheet);
-    document.head.appendChild(script);
-  }
-</script>
-```
+<Tabs>
+  <Tab title="ES build (module-aware)">
+    ```html
+    <script type="module">
+      function loadAgentsCdn(version, done) {
+        const stylesheet = document.createElement("link");
+        stylesheet.rel = "stylesheet";
+        stylesheet.type = "text/css";
+        stylesheet.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/style.css`;
+
+        const script = document.createElement("script");
+        script.type = "module";
+        script.onload = done;
+        script.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/dv-agent.es.js`;
+
+        document.head.appendChild(stylesheet);
+        document.head.appendChild(script);
+      }
+    </script>
+    ```
+  </Tab>
+  <Tab title="UMD build (jQuery or legacy)">
+    ```html
+    <script>
+      function loadAgentsCdn(version, done) {
+        const stylesheet = document.createElement("link");
+        stylesheet.rel = "stylesheet";
+        stylesheet.type = "text/css";
+        stylesheet.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/style.css`;
+
+        const script = document.createElement("script");
+        script.type = "text/javascript";
+        script.onload = done;
+        script.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/dv-agent.umd.js`;
+
+        document.head.appendChild(stylesheet);
+        document.head.appendChild(script);
+      }
+    </script>
+    ```
+  </Tab>
+</Tabs>
 
 <Tip>
-Use `latest` while exploring in development. For production, pin the tested CDN version and update CSP entries to match your pinned policy.
+Use `latest` while exploring in development. For production, pin the tested CDN version and update CSP entries to match the bundle (`dv-agent.es.js` or `dv-agent.umd.js`) you ship.
 </Tip>
 
 ## Base configuration

--- a/get-started/guides/embedding-widget-production-qa-security.mdx
+++ b/get-started/guides/embedding-widget-production-qa-security.mdx
@@ -42,15 +42,25 @@ script-src 'self' https://cdn.jsdelivr.net;
 style-src 'self' https://cdn.jsdelivr.net;
 ```
 
-If your policy pins exact asset paths, match the CDN version used by the loader.
+If your policy pins exact asset paths, match the CDN version and the bundle filename used by the loader. The widget ships an ES build for module-aware setups and a UMD build for jQuery and legacy pages, so the pinned path differs between integrations.
 
-```text
-script-src 'self' https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@1.0.19/dist/dv-agent.es.js;
-style-src 'self' https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@1.0.19/dist/style.css;
-```
+<Tabs>
+  <Tab title="ES build">
+    ```text
+    script-src 'self' https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@1.0.19/dist/dv-agent.es.js;
+    style-src 'self' https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@1.0.19/dist/style.css;
+    ```
+  </Tab>
+  <Tab title="UMD build">
+    ```text
+    script-src 'self' https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@1.0.19/dist/dv-agent.umd.js;
+    style-src 'self' https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@1.0.19/dist/style.css;
+    ```
+  </Tab>
+</Tabs>
 
 <Tip>
-Keep the loader version, CSP entries, and release notes for your deployment in sync. A mismatch can make the widget work in staging and fail in production.
+Keep the loader version, the bundle filename, CSP entries, and release notes for your deployment in sync. A mismatch can make the widget work in staging and fail in production.
 </Tip>
 
 ## CDN version pinning
@@ -111,6 +121,7 @@ loadAgentsCdn("1.0.19", function () {
 |---|---|
 | Trigger button does not appear | Confirm the CDN script loaded, CSP is not blocking assets, and `loadAgent` runs after the CDN callback. |
 | Widget appears on staging but not production | Confirm the production domain is in Whitelist Domains and CSP uses the same pinned CDN version. |
+| jQuery `$` is undefined or host page globals are clobbered after the widget loads | The page is loading `dv-agent.es.js` as a plain `<script>`. Swap the loader to `dv-agent.umd.js` and update the pinned CSP path to match. |
 | Voice call cannot start | Confirm microphone permission, browser support, and that the assistant is configured for Webcall. |
 | Chat opens in the wrong mode | Confirm `defaultTab` and `hideTabSelector` in the deployed `loadAgent` config. |
 | Analytics fire twice | Remove duplicate event listeners during single-page app navigation. |

--- a/get-started/guides/embedding-widget.mdx
+++ b/get-started/guides/embedding-widget.mdx
@@ -51,35 +51,76 @@ The widget snippet runs in the browser and includes `xApiKey`. Use only the embe
   </Step>
 
   <Step title="Add the widget snippet">
-    Paste this near the end of the page, preferably before the closing `</body>` tag.
+    Paste this near the end of the page, preferably before the closing `</body>` tag. Pick the bundle that matches your host page.
 
-    ```html
-    <script>
-      function loadAgentsCdn(version, done) {
-        const stylesheet = document.createElement("link");
-        stylesheet.rel = "stylesheet";
-        stylesheet.type = "text/css";
-        stylesheet.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/style.css`;
+    <Tabs>
+      <Tab title="Modern bundler or module-aware page">
+        Use `dv-agent.es.js` when the page is built with Vite, webpack, Next, or any other module-aware setup, or when the snippet runs inside `<script type="module">`.
 
-        const script = document.createElement("script");
-        script.type = "text/javascript";
-        script.onload = done;
-        script.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/dv-agent.es.js`;
+        ```html
+        <script type="module">
+          function loadAgentsCdn(version, done) {
+            const stylesheet = document.createElement("link");
+            stylesheet.rel = "stylesheet";
+            stylesheet.type = "text/css";
+            stylesheet.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/style.css`;
 
-        document.head.appendChild(stylesheet);
-        document.head.appendChild(script);
-      }
+            const script = document.createElement("script");
+            script.type = "module";
+            script.onload = done;
+            script.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/dv-agent.es.js`;
 
-      loadAgentsCdn("latest", function () {
-        loadAgent({
-          agentId: "your-agent-id",
-          xApiKey: "your-api-key",
-          variables: {},
-          buttons: {},
-        });
-      });
-    </script>
-    ```
+            document.head.appendChild(stylesheet);
+            document.head.appendChild(script);
+          }
+
+          loadAgentsCdn("latest", function () {
+            loadAgent({
+              agentId: "your-agent-id",
+              xApiKey: "your-api-key",
+              variables: {},
+              buttons: {},
+            });
+          });
+        </script>
+        ```
+      </Tab>
+      <Tab title="jQuery or legacy page">
+        Use `dv-agent.umd.js` when the host page uses jQuery, an older CMS theme, or any plain `<script>` setup without a module bundler.
+
+        ```html
+        <script>
+          function loadAgentsCdn(version, done) {
+            const stylesheet = document.createElement("link");
+            stylesheet.rel = "stylesheet";
+            stylesheet.type = "text/css";
+            stylesheet.href = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/style.css`;
+
+            const script = document.createElement("script");
+            script.type = "text/javascript";
+            script.onload = done;
+            script.src = `https://cdn.jsdelivr.net/npm/@desivocal/agents-cdn@${version}/dist/dv-agent.umd.js`;
+
+            document.head.appendChild(stylesheet);
+            document.head.appendChild(script);
+          }
+
+          loadAgentsCdn("latest", function () {
+            loadAgent({
+              agentId: "your-agent-id",
+              xApiKey: "your-api-key",
+              variables: {},
+              buttons: {},
+            });
+          });
+        </script>
+        ```
+      </Tab>
+    </Tabs>
+
+    <Note>
+    The ES bundle is only safe inside module-aware setups. Loading `dv-agent.es.js` as a plain `<script>` leaks internals onto `window` and can clobber host page globals like jQuery's `$`. Reach for the UMD build on any non-module page.
+    </Note>
 
     For production, pin a tested CDN version instead of `latest` after validating the widget in staging.
   </Step>


### PR DESCRIPTION
The widget ships an ES build and a UMD build, but the docs only showed the ES loader. Integrators on jQuery or other legacy pages were hitting `window` leakage and `$` clobbering when loading `dv-agent.es.js` as a plain `<script>`.

- Quickstart (`embedding-widget.mdx`): snippet split into ES (module-aware) and UMD (jQuery/legacy) tabs with a Note on the clobber risk.
- Configuration reference: new "Choosing the bundle" table plus warning under CDN loader, with both loader variants in tabs.
- Production QA: pinned CSP examples for both bundles and a new troubleshooting row for the jQuery `$` clobber symptom.