### PR TITLE
[Prod] - docs(widget): Components (Block Kit) primary, mark calendar/form widgets legacy

### DIFF
--- a/get-started/guides/embedding-widget-chat-widgets.mdx
+++ b/get-started/guides/embedding-widget-chat-widgets.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Embedding Widget Chat and Widgets"
-sidebarTitle: "Chat and Widgets"
+title: "Embedding Widget Chat and Components"
+sidebarTitle: "Chat and Components"
 icon: "message-square"
-description: "Configure chat mode, chat-only embeds, calendar widgets, form widgets, and chat assistant prompts."
+description: "Configure chat mode, chat-only embeds, interactive Components (Block Kit), and chat assistant prompts."
 ---
 
-The Ringg widget supports text-based chat alongside voice calls. In chat mode, users type messages while the same assistant can still use configured tools, knowledge base queries, callback scheduling, and form widgets.
+The Ringg widget supports text-based chat alongside voice calls. In chat mode, users type messages while the same assistant can still use configured tools, knowledge base queries, and interactive Components.
 
 ## Set up a chat agent
 
@@ -85,23 +85,27 @@ Create a dedicated assistant for chat by cloning your voice assistant. Chat conv
   </Card>
 </CardGroup>
 
-## Chat widgets
+## Components
 
-Chat widgets are interactive UI components the assistant can present during a conversation. They render inside the chat interface so users can schedule callbacks, submit forms, or book appointments without leaving the widget.
+Components are interactive UI the assistant presents during a conversation — cards, forms, pickers, ratings, and more — rendered inside the chat so users can act without leaving it. Components are built with **Block Kit** (see below) and are the current standard for all new builds.
 
 <Note>
-Chat widgets work best in text mode. They can also be triggered during voice calls, but visual interaction is most natural in the chat interface.
+Components work best in text mode. They can also be triggered during voice calls, but visual interaction is most natural in the chat interface.
 </Note>
 
-The widget flow is:
+The flow is:
 
-1. The assistant decides a widget is needed and calls the `send_widgets` tool.
-2. The widget renders inside the chat.
-3. The user selects a time slot or submits form data.
+1. The assistant decides a component is needed and streams a Block Kit tree.
+2. The component renders inside the chat.
+3. The user taps a button, fills inputs, or picks a rating.
 4. The response is sent back to the assistant automatically.
-5. The assistant confirms the action and can trigger an API call if `api_config` is provided.
+5. The assistant confirms the action and can trigger an API call if configured.
 
-## Calendar widget
+<Warning>
+The fixed-purpose **Calendar** and **Form** widgets below (the `send_widgets` tool with `calender_widget_tool` / `form_widget_tool`) are **legacy**. Existing agents keep working, but new builds should use **Components** (Block Kit) — a carousel of plan cards, a booking form, or a rating card are all expressible as blocks.
+</Warning>
+
+## Calendar widget (legacy)
 
 Use the calendar widget for callback scheduling, demo booking, consultations, or follow-up appointments. Past slots are excluded so users see valid options.
 
@@ -143,7 +147,7 @@ The required `tool_type` value is `calender_widget_tool`. Use that exact spellin
 
 When a user schedules a callback, the selected datetime and timezone are sent back to the assistant. If `api_config` is provided, the booking data is forwarded to your API.
 
-## Form widget
+## Form widget (legacy)
 
 Use the form widget for contact details, lead qualification, support tickets, addresses, surveys, or other structured data collection.
 
@@ -207,6 +211,32 @@ Use the form widget for contact details, lead qualification, support tickets, ad
 ```
 
 When the user submits the form, the collected data is sent back to the assistant. If `api_config` is provided, the data is also forwarded to your API endpoint.
+
+## Block Kit — the Components system
+
+Block Kit is the engine behind **Components**: the assistant builds a tree of typed blocks (cards, carousels, tables, inputs, buttons, ratings, and more) that render inside the chat. Unlike the fixed legacy calendar and form widgets, Block Kit lets the assistant lay out arbitrary content — plan comparisons, order trackers, feedback cards, or rich confirmations — and is the recommended path for all new builds.
+
+<Note>
+Block Kit trees are streamed on the `ringg.blocks` topic (not a fixed tool), so payloads have no practical size limit. The widget renders them and reports interactions back to the assistant automatically.
+</Note>
+
+How it works:
+
+1. The assistant resolves a fully-concrete block tree server-side (bindings filled, lists expanded) and streams it.
+2. The widget renders it full-width in the transcript.
+3. The user taps a button, fills inputs, or picks a rating.
+4. The interaction is sent back to the assistant; a tap is treated as one conversation turn, so the card locks after responding.
+
+The block **type catalog** (currently `1.4`) defines the available blocks and their props:
+
+| Group | Types |
+|---|---|
+| Layout | `box`, `row`, `column`, `card`, `carousel`, `form`, `expander` |
+| Content | `header`, `text`, `image`, `divider`, `badge`, `callout`, `facts`, `table`, `steps` |
+| Inputs | `input_text`, `input_email`, `input_phone_number`, `input_number`, `input_date`, `input_time`, `input_textarea`, `input_checkbox`, `input_single_select`, `input_multi_select`, `input_rating` |
+| Action | `button` |
+
+Most content and action blocks share a `size` (`sm` / `md` / `lg`) and `align` vocabulary; `image` uses `width` (`sm` / `md` / `full`) and `button` supports `full_width`. Blocks inherit the widget theme (colors, radius, button style), and every rendered node exposes a `data-ringg="block-<type>"` hook for CSS — see [Customization](/get-started/guides/embedding-widget-customization#block-kit).
 
 ## Complete chat-only embed
 

--- a/get-started/guides/embedding-widget-configuration.mdx
+++ b/get-started/guides/embedding-widget-configuration.mdx
@@ -113,14 +113,33 @@ loadAgentsCdn("latest", function () {
 | `authorization` | `string` | Required | `Bearer <webcall-public-key>`. The webcall public key is generated for the assistant in the dashboard embed code and can be rotated from there. |
 | `variables` | `object` | `{}` | Runtime variables available to the assistant. |
 | `defaultTab` | `"audio" \| "text"` | `"audio"` | Tab shown when the widget loads. Use `"text"` for chat mode. Supported from v1.0.8+. |
-| `hideTabSelector` | `boolean` | `false` | Hides the audio/text tab switcher for a single-mode experience. Supported from v1.0.8+. |
+| `hideTabSelector` | `boolean` | `false` | Pins the widget to `defaultTab` (single-mode start screen). Supported from v1.0.8+. |
 | `bypassStartScreen` | `boolean` | `false` | Skips the start screen and begins a call or chat immediately on trigger click. Uses `defaultTab`. |
 | `title` | `string` | Unset | Heading shown in the widget start screen. |
 | `description` | `string` | Unset | Supporting copy shown in the widget start screen. |
-| `logoUrl` | `string` | Unset | Logo image URL shown in the widget. |
+| `logoUrl` | `string` | Unset | Logo image URL shown in the header and, when set, the launcher. |
+| `typingWords` | `string[]` | `["Thinking", "Reasoning", "Working on it", "Almost there"]` | Words cycled in the pending-reply indicator (shimmered, "Thinking…" style). |
+| `theme` | `object` | Unset | Widget color theme (see below). |
 | `buttons` | `object` | `{}` | Trigger and call button customization. |
 | `widgetPosition` | `object` | Fixed bottom-right | Placement rules for the trigger and expanded widget. |
-| `feedbackScreen` | `object` | Unset | Text for the post-conversation feedback screen. |
+| `feedbackScreen` | `object` | Unset | Text and star colors for the post-conversation feedback screen. |
+
+### Theme
+
+Pass `theme` to color the widget. Colors accept a solid value or a CSS gradient string.
+
+| Field | Description |
+|---|---|
+| `theme.primaryColor` | Accent for buttons, selected states, the launcher, and the shimmer. |
+| `theme.primaryTextColor` | Text on the primary color. |
+| `theme.backgroundColor` | Widget background. |
+| `theme.surfaceColor` | Cards, inputs, and the user message bubble. |
+| `theme.agentBubbleColor` | When set, agent messages render inside a bubble with this background (accepts a gradient). Unset = agent messages are bubble-less plain text. |
+| `theme.textColor` / `theme.mutedTextColor` | Body and secondary text. |
+| `theme.borderColor` | Borders and dividers. |
+| `theme.errorColor` / `theme.successColor` | Validation, danger, and success states. |
+| `theme.borderRadius` | Corner radius for the panel, cards, and inputs. |
+| `theme.buttonStyle` | `"pill"` / `"rounded"` / `"square"` — button corner style. |
 
 ## Variables
 

--- a/get-started/guides/embedding-widget-customization.mdx
+++ b/get-started/guides/embedding-widget-customization.mdx
@@ -35,35 +35,38 @@ State-bearing elements expose additional `data-ringg-<state>` attributes. They u
 
 | Attribute | Values | Emitted on |
 |---|---|---|
-| `data-ringg-active` | `"true"` / `"false"` | `tab`, `slash-command-item` |
-| `data-ringg-lit` | `"true"` / `"false"` | `voice-animation-dot` |
 | `data-ringg-role` | `"agent"` / `"user"` | `message` |
+| `data-ringg-muted` | `"true"` / `"false"` | `mute-button` |
+| `data-ringg-connecting` | `"true"` / `"false"` | `header-status-dot` |
+| `data-ringg-align` | `"center"` / `"end"` | `quick-replies` (centered in voice, right-aligned in chat) |
+| `data-ringg-style` | `"primary"` / `"secondary"` / `"outline"` / `"destructive"` | `quick-reply-button`, `option-row` |
+| `data-ringg-variant` | `"transcript"` | `feedback-screen` (present when the ended transcript stays readable) |
+| `data-ringg-active` | `"true"` / `"false"` | `slash-command-item` |
+| `data-ringg-lit` | `"true"` / `"false"` | `voice-animation-dot` |
 | `data-ringg-level` | `"info"` / `"error"` | `system-log` |
 | `data-ringg-step-active` | `"true"` / `"false"` | `flow-step` |
 | `data-ringg-step-completed` | `"true"` / `"false"` | `flow-step` |
-| `data-ringg-tab-id` | tab id string, for example `"audio"`, `"text"` | `tab` |
+| `data-block-id` | authored id string | any Block Kit node with an author id |
+| `data-action-id` | action id string | `block-button` |
 
 Compound selector example:
 
 ```css
-[data-ringg="tab"][data-ringg-active="true"] {
-  color: var(--brand-primary);
-  border-bottom-color: var(--brand-primary);
+[data-ringg="mute-button"][data-ringg-muted="true"] {
+  background: var(--brand-danger);
 }
 ```
 
 Observer example:
 
 ```javascript
-const audioTab = document.querySelector(
-  '[data-ringg="tab"][data-ringg-tab-id="audio"]'
-);
+const muteButton = document.querySelector('[data-ringg="mute-button"]');
 
 new MutationObserver(() => {
-  console.log("audio tab active?", audioTab.getAttribute("data-ringg-active"));
-}).observe(audioTab, {
+  console.log("muted?", muteButton.getAttribute("data-ringg-muted"));
+}).observe(muteButton, {
   attributes: true,
-  attributeFilter: ["data-ringg-active"],
+  attributeFilter: ["data-ringg-muted"],
 });
 ```
 
@@ -86,7 +89,10 @@ Elements are grouped by where they appear in the widget.
 | `body-spacer` | Empty placeholder that keeps controls anchored when the body is empty. |
 | `transcript` | Scrollable message area. |
 | `transcript-list` | Inner flex list of messages. |
-| `attached-buttons` | Wrapper for inline buttons attached to an agent message. |
+| `controls-bar` | Transparent bar anchoring the message input over the transcript (chat mode). The transcript scrolls underneath it. |
+| `attached-buttons` | Full-width wrapper for quick replies rendered directly below an agent message. |
+| `connecting-status` | Wrapper for the pre-call connecting state ("Connecting…" label + loading bar). |
+| `connecting-label` | The `"Connecting…"` `<p>` above the loading bar. |
 | `error-message` | Inline error text. |
 | `legal-disclaimer` | Pre-call legal `<p>`. |
 | `legal-link-privacy` | Privacy policy link inside the legal disclaimer. |
@@ -96,32 +102,35 @@ Elements are grouped by where they appear in the widget.
 
 | `data-ringg` | Element |
 |---|---|
-| `header` | Header container. Only present during a call (absolute-positioned band). |
-| `header-logo` | Logo circle. Both pre-call and in-call. |
-| `header-logo-image` | The `<img>` inside the logo circle. |
-| `header-text` | Text column wrapper that holds the title and description/status. |
+| `header` | In-call header band. **Only present during a call** — integrators use this to detect an active call (e.g. `:has([data-ringg="header"])`). Absolute-positioned frosted overlay. |
+| `intro` | Pre-call container. Centered logo/title/description block on the start screen (the pre-call counterpart to `header`). |
+| `header-logo` | Logo chip. Both pre-call (rounded square) and in-call. |
+| `header-logo-image` | The `<img>` inside the logo chip. |
+| `header-text` | Text wrapper that holds the title and description. |
 | `header-title` | Title `<h2>`. |
-| `header-description` | Pre-call description `<p>`. Only present pre-call. |
-| `header-status` | Status `<p>` shown during a call (`"Connecting…"`, `"Call in Progress"`). |
+| `header-description` | Description `<p>`. Shown pre-call and in-call. Truncated in-call (full text on hover via `title`). |
+| `header-status-dot` | Presence dot. In-call only. Carries `data-ringg-connecting` — muted + pulsing while connecting, success-colored once live. |
+| `header-status` | Screen-reader-only status `<p>`. In-call only; visible status is the dot. The pre-call connecting status moved to `connecting-label`. |
 
 ### Call controls (audio mode)
+
+Compact centered mute/end pair, no text labels — icons carry the meaning.
 
 | `data-ringg` | Element |
 |---|---|
 | `call-controls` | Row container holding the call control buttons. |
-| `mute-control` | Mute column wrapping the button + label. |
-| `mute-button` | Mute toggle button. |
-| `mute-label` | `"Mute"` / `"Unmute"` text under the button. |
-| `end-call-control` | End-call column wrapping the button + label. |
-| `end-call-button` | End-call button. |
-| `end-call-label` | `"End Call"` text under the button. |
+| `mute-button` | Mute toggle button (aria-label `"Mute"` / `"Unmute"`). Carries `data-ringg-muted`. |
+| `end-call-button` | End-call button (aria-label `"End call"`). |
 
 ### Action buttons (start screen)
 
+The start screen shows both buttons side by side (Chat left, Call right), each starting its mode directly. With `hideTabSelector: true` only the `defaultTab` mode's button renders, full-width.
+
 | `data-ringg` | Element |
 |---|---|
-| `start-call-button` | Start-call button. Rendered when `callMode === "audio"`. |
-| `start-chat-button` | Start-chat button. Rendered when `callMode === "text"`. |
+| `start-actions` | Row wrapping the Chat + Call pair. Only when both buttons are shown. |
+| `start-call-button` | Starts a voice call. |
+| `start-chat-button` | Starts a chat. |
 
 ### Loading bar
 
@@ -131,25 +140,37 @@ Elements are grouped by where they appear in the widget.
 | `loading-bar-track` | Background track. |
 | `loading-bar-fill` | Animated fill. |
 
-### Tabs
+### Quick replies and options
+
+Quick-reply chips (`free` presentation) and boxed option lists rendered below an agent message.
 
 | `data-ringg` | Element |
 |---|---|
-| `tabs` | Outer container with top border. |
-| `tabs-list` | Row of tab buttons. |
-| `tab` | Individual tab button. Carries `data-ringg-tab-id` and `data-ringg-active`. |
-| `tab-label` | Tab label `<span>`. |
+| `quick-replies` | Chip row container. Carries `data-ringg-align` (`"center"` in voice, `"end"` in chat). |
+| `quick-reply-button` | Each pill chip. Carries `data-ringg-style`. |
+| `buttons-step-title` | Optional title `<p>` above the chips. |
+| `options-list` | Boxed single-choice list container (rows divided by hairlines). |
+| `option-row` | Each option row. Carries `data-ringg-style`. |
+| `option-radio` | Radio affordance inside an option row. |
+
+### Typing indicator
+
+Shown while an agent reply is pending. Cycles through words (default: Thinking / Reasoning / Working on it / Almost there; override with the `typingWords` config) each rendered with a left→right text shimmer.
+
+| `data-ringg` | Element |
+|---|---|
+| `typing-indicator` | Outer row. |
+| `typing-indicator-word` | The shimmering current word `<span>`. |
 
 ### Messages
 
 | `data-ringg` | Element |
 |---|---|
 | `message` | Outer message row. Carries `data-ringg-role="agent"` / `"user"`. |
-| `message-bubble` | The bubble inside a message row. |
+| `message-bubble` | The bubble inside a message row. Agent messages are bubble-less unless the theme sets `agentBubbleColor`. |
 | `message-content` | Inner column inside the bubble. |
 | `message-body` | Markdown-rendered message body. |
 | `message-source` | "Source:" link rendered below a message. |
-| `message-attachment` | Wrapper for embedded interactive content (buttons, forms, etc). |
 
 ### System log pill
 
@@ -210,12 +231,27 @@ The system log pill renders the inline activity feed in the transcript. It only 
 | `data-ringg` | Element |
 |---|---|
 | `message-input-form` | The `<form>` element. |
-| `message-input` | Outer pill container. Also wraps the slash menu when open. |
+| `message-input` | Outer pill container — carries the frosted-glass treatment; transparent gutters. Also wraps the slash menu when open (going solid). |
 | `message-input-row` | Row containing the input field + send button. |
 | `message-input-field` | The `<input>` element. |
 | `message-send-button` | Send arrow button. |
 
 ### Feedback screen
+
+When the ended conversation has text messages, the transcript stays readable and the rating renders as a footer below it (`data-ringg-variant="transcript"`); tapping a star submits immediately. The legacy centered card (comment box + submit/skip) renders when there is no transcript.
+
+**Transcript variant**
+
+| `data-ringg` | Element |
+|---|---|
+| `feedback-screen` | Container. Carries `data-ringg-variant="transcript"`. |
+| `feedback-footer` | Divider + prompt + stars block below the read-only conversation. |
+| `conversation-ended` | "Conversation ended" hairline divider row. |
+| `feedback-prompt` | "Please rate your experience" `<p>`. |
+| `feedback-stars` | Star row. |
+| `feedback-star` | Each star button. Carries `data-ringg-filled`. |
+
+**Legacy centered card**
 
 | `data-ringg` | Element |
 |---|---|
@@ -229,6 +265,18 @@ The system log pill renders the inline activity feed in the transcript. It only 
 | `feedback-actions` | Submit + skip wrapper. |
 | `feedback-submit` | Submit button. |
 | `feedback-skip` | Skip button. |
+
+### Block Kit
+
+Composable widget trees the agent streams on the `ringg.blocks` topic (see [Chat and Widgets](/get-started/guides/embedding-widget-chat-widgets)). Rendered full-width in the transcript.
+
+| `data-ringg` | Element |
+|---|---|
+| `blocks-widget` | Transcript wrapper around one Block Kit instance. |
+| `blocks` | Root of the rendered tree. |
+| `block-<type>` | Every rendered node, named by its catalog type (e.g. `block-card`, `block-carousel`, `block-table`, `block-steps`, `block-input_rating`). Carries `data-block-id` when the author set one. |
+| `block-button` | Action button. Carries `data-block-id` and `data-action-id`. |
+| `blocks-unsupported` | Fallback `<p>` when the payload needs a newer widget version. |
 
 ### Footer
 
@@ -262,12 +310,12 @@ The end-call confirm dialog renders in a portal **outside** `[data-ringg="widget
 }
 ```
 
-### Highlight the active tab
+### Style the muted state
 
 ```css
-[data-ringg="tab"][data-ringg-active="true"] {
-  color: var(--brand-primary);
-  border-bottom-color: var(--brand-primary);
+[data-ringg="mute-button"][data-ringg-muted="true"] {
+  background: var(--brand-danger);
+  color: #fff;
 }
 ```
 
@@ -334,6 +382,6 @@ For lifecycle hooks like open/close, conversation start/end, and the feedback pa
 ## QA notes
 
 <Check>All your selectors target `[data-ringg="..."]` attributes, not internal `ringg_ai-*` class names.</Check>
-<Check>Compound selectors with state attributes (for example `[data-ringg="tab"][data-ringg-active="true"]`) update live as the widget changes state.</Check>
+<Check>Compound selectors with state attributes (for example `[data-ringg="mute-button"][data-ringg-muted="true"]`) update live as the widget changes state.</Check>
 <Check>Selectors for the end-call confirm dialog are document-scoped, not nested under `[data-ringg="widget-root"]`.</Check>
 <Check>CSS transitions on `[data-ringg-lit]` are lightweight, so per-frame state changes do not cause jank.</Check>


### PR DESCRIPTION
Updates the embeddable-widget guides for the agents-cdn redesign and the widgets→Components shift.

## Chat and Components (`embedding-widget-chat-widgets.mdx`)
- Reframe `## Chat widgets` → `## Components` — Block Kit is the current standard for interactive UI the agent shows in chat.
- Mark the fixed-purpose **Calendar** and **Form** widgets as **legacy** (`send_widgets` / `calender_widget_tool` / `form_widget_tool`) — matches the app's own "New builds should use components" copy.
- Add the Block Kit type catalog (1.4) grouped by layout/content/inputs/action, plus the size/align/width/full_width vocabulary.
- Frontmatter title/description updated to Components.

## Customization — data-ringg reference (`embedding-widget-customization.mdx`)
- Remove drifted attributes that no longer render: `tabs`/`tabs-list`/`tab`/`tab-label`, `mute-control`/`mute-label`/`end-call-control`/`end-call-label`.
- Add redesign attributes: `intro`, `controls-bar`, `connecting-status`/`connecting-label`, `start-actions`, `header-status-dot`, quick replies (`quick-replies` + `data-ringg-align`, `quick-reply-button`/`option-row` + `data-ringg-style`), typing indicator (`typing-indicator-word`), feedback transcript variant (`data-ringg-variant`, `feedback-footer`, `conversation-ended`, `feedback-prompt`), and a Block Kit section (`blocks-widget`, `block-<type>`, `block-button` + `data-block-id`/`data-action-id`).
- Refresh the state-attributes table, recipe, and QA examples to the current attributes.

## Configuration (`embedding-widget-configuration.mdx`)
- Add `typingWords` and a **Theme** subsection (primary/surface/`agentBubbleColor`/text/border/radius/buttonStyle).