### PR TITLE
docs(trai): calling window default 8AM-8PM → 9AM-9PM

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -5794,8 +5794,8 @@
                       "call_time": {
                         "type": "object",
                         "properties": {
-                          "call_start_time": { "type": "string", "default": "08:00", "example": "09:00" },
-                          "call_end_time": { "type": "string", "default": "20:00", "example": "18:00" },
+                          "call_start_time": { "type": "string", "default": "09:00", "example": "09:00" },
+                          "call_end_time": { "type": "string", "default": "21:00", "example": "18:00" },
                           "timezone": { "type": "string", "default": "Asia/Kolkata", "example": "Asia/Kolkata" },
                           "scheduled_at": {
                             "type": "string",


### PR DESCRIPTION
## What

TRAI now permits outbound calls only between **9AM and 9PM** (was 8AM–8PM). Update the documented `call_config.call_time` default in the OpenAPI spec to match the backend.

## Change (`api-reference/openapi.json`)
```diff
- "call_start_time": { "type": "string", "default": "08:00", "example": "09:00" },
- "call_end_time":   { "type": "string", "default": "20:00", "example": "18:00" },
+ "call_start_time": { "type": "string", "default": "09:00", "example": "09:00" },
+ "call_end_time":   { "type": "string", "default": "21:00", "example": "18:00" },
```

Only the block documenting the `08:00`/`20:00` default is changed. JSON validated.

## Context
Counterpart to backend #2896 (defaults + data migration, merged & deployed) and FE #562/#561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)