### PR TITLE
[Prod] docs: add Security and Compliance page under Privacy and Compliance

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -215,6 +215,12 @@
         "pages": [
           "external-integrations/truefoundry-integration"
         ]
+      },
+      {
+        "group": "Privacy and Compliance",
+        "pages": [
+          "privacy-and-compliance/security-and-compliance"
+        ]
       }
     ]
   },

--- a/privacy-and-compliance/security-and-compliance.mdx
+++ b/privacy-and-compliance/security-and-compliance.mdx
@@ -1,0 +1,58 @@
+---
+title: "Security and Compliance"
+sidebarTitle: "Security and Compliance"
+description: "Ringg AI is HIPAA and GDPR compliant, SOC 2 Type II audited, and ISO 27001 certified. Review security controls, agreements, and data erasure."
+icon: "badge-check"
+"og:title": "Ringg AI Security & Compliance: SOC 2 Type II, ISO 27001, HIPAA & GDPR"
+---
+
+Ringg AI is HIPAA and GDPR compliant, has completed a SOC 2 Type II audit, and is ISO 27001 certified.
+
+Ringg AI is built for businesses that need to run customer conversations securely and responsibly. We protect customer data through documented security controls, privacy practices, and safeguards designed for production voice AI workflows.
+
+These measures help protect the confidentiality, integrity, and availability of data handled through Ringg.
+
+## Certifications and compliance
+
+Ringg maintains the following certifications and compliance programs:
+
+<CardGroup cols={2}>
+  <Card title="SOC 2 Type II" icon="clipboard-check">
+    Ringg has completed a SOC 2 Type II audit, which evaluates the design and operating effectiveness of controls over a defined period.
+  </Card>
+  <Card title="ISO 27001" icon="shield-check">
+    Ringg is certified to ISO 27001, the international standard for information security management systems.
+  </Card>
+  <Card title="GDPR" icon="scale">
+    Ringg is GDPR compliant and supports applicable data-subject rights, appropriate safeguards for cross-border transfers, and the data processing practices described in our [Privacy Policy](https://www.ringg.ai/privacy).
+  </Card>
+  <Card title="HIPAA" icon="stethoscope">
+    Ringg is HIPAA compliant and supports appropriately configured voice AI workflows for healthcare organizations.
+  </Card>
+</CardGroup>
+
+Access certificates, reports, and the latest audit status in the Compliance Trust Center.
+
+## Agreements and compliance documentation
+
+Customers may need additional agreements before using Ringg with regulated data:
+
+- **Business Associate Agreement (BAA)**: A signed BAA is required before protected health information (PHI) is transmitted through Ringg for a covered healthcare workflow.
+- **Data Processing Addendum (DPA)**: Describes how personal data is processed and the responsibilities of Ringg and the customer.
+- **Standard Contractual Clauses (SCCs)**: May provide an approved transfer mechanism when personal data is transferred internationally.
+
+Contact [admin@ringg.ai](mailto:admin@ringg.ai) to request compliance documentation or to confirm which agreements apply to your use case.
+
+## Request deletion of personal data
+
+To request access, correction, or deletion of personal data associated with you, email [admin@ringg.ai](mailto:admin@ringg.ai). Include enough information for Ringg to identify the relevant account or data without sending unnecessary sensitive information.
+
+Ringg may need to verify your identity before completing a request. Some information may be retained where required by law or for legitimate security, fraud-prevention, dispute-resolution, or contractual purposes.
+
+<Note>
+  See [Security Guidelines](/get-started/best-practices/security-guidelines) for implementation guidance.
+</Note>
+
+## Need more information?
+
+For compliance reports, certificates, security reviews, vendor assessments, subprocessors, data-protection questions, or agreement requests, contact [admin@ringg.ai](mailto:admin@ringg.ai).

--- a/privacy-and-compliance/security-and-compliance.mdx
+++ b/privacy-and-compliance/security-and-compliance.mdx
@@ -1,9 +1,10 @@
 ---
 title: "Security and Compliance"
 sidebarTitle: "Security and Compliance"
-description: "Ringg AI is HIPAA and GDPR compliant, SOC 2 Type II audited, and ISO 27001 certified. Review security controls, agreements, and data erasure."
 icon: "badge-check"
 "og:title": "Ringg AI Security & Compliance: SOC 2 Type II, ISO 27001, HIPAA & GDPR"
+"og:description": "Ringg AI is HIPAA and GDPR compliant, SOC 2 Type II audited, and ISO 27001 certified. Review security controls, agreements, and data erasure."
+"twitter:description": "Ringg AI is HIPAA and GDPR compliant, SOC 2 Type II audited, and ISO 27001 certified. Review security controls, agreements, and data erasure."
 ---
 
 Ringg AI is HIPAA and GDPR compliant, has completed a SOC 2 Type II audit, and is ISO 27001 certified.
@@ -31,7 +32,7 @@ Ringg maintains the following certifications and compliance programs:
   </Card>
 </CardGroup>
 
-Access certificates, reports, and the latest audit status in the Compliance Trust Center.
+Access certificates, reports, and the latest audit status in the [Compliance Trust Center](https://ringg-ai.in.trust.site/).
 
 ## Agreements and compliance documentation
 


### PR DESCRIPTION
Documents SOC 2 Type II, ISO 27001, GDPR, and HIPAA status; the BAA/DPA/SCC agreements customers may need before sending regulated data; and how to request access, correction, or deletion of personal data.