### PR TITLE
docs(calling): document call deadlines on the initiate endpoints

### DIFF
--- a/api-reference/endpoint/calling/initiate-individual-call-v2.mdx
+++ b/api-reference/endpoint/calling/initiate-individual-call-v2.mdx
@@ -68,6 +68,56 @@ Use `custom_args_values` to pass dynamic data to your assistant.
 
 For example, `Mr Rajesh Kumar` can become `Rajesh` or a transliterated value in `callee_name`. The original name is preserved as `original_callee_name` in `custom_args_values`.
 
+## Call deadlines
+
+A queued call is not always dialled straight away: it waits for the allowed calling
+window, for a free concurrency slot, and for any retry backoff. Set a deadline when a
+call stops being worth making after a certain point — an appointment reminder for a slot
+that has passed, or an offer that has expired.
+
+Two ways to express it. Both are optional, and both are honoured on `POST /calling/outbound/individual`
+and its v2 counterpart.
+
+| Field | Meaning | Use when |
+|---|---|---|
+| `call_deadline` | Absolute instant, ISO 8601 | You have a real-world cut-off: `"2026-08-27T18:00:00+05:30"` |
+| `call_validity_hours` | Hours from creation (or from `scheduled_at`) | You have a duration: `2` means "useless after two hours" |
+
+```json
+{
+  "name": "John Doe",
+  "mobile_number": "+919876543210",
+  "agent_id": "your-agent-id",
+  "from_number_id": "your-from-number-id",
+  "call_deadline": "2026-08-27T18:00:00+05:30"
+}
+```
+
+<Warning>
+**Always include a UTC offset in `call_deadline`.** A value without one — `"2026-08-27T18:00:00"` —
+is read as UTC, so a cut-off you meant as 18:00 IST would take effect at 23:30 IST.
+</Warning>
+
+If both fields are set, the **earlier** deadline applies. They do not override one
+another: a call is never dialled past the tightest cut-off you supplied.
+
+### What happens when the deadline passes
+
+The call is **never placed**. When the picker next reaches a call whose deadline has
+passed, it ends it immediately:
+
+| | |
+|---|---|
+| `status` | `cancelled` |
+| `sub_status` | `DEADLINE_PASSED` |
+
+Nothing is dialled, no carrier request is made, and no credits are consumed. The call
+also stops being retried — a deadline that has passed ends the call whether or not it is
+inside the calling window.
+
+Calls with no deadline are unaffected: omit both fields and the call waits as long as it
+needs to.
+
 ## Result handling
 
 Store the returned call ID. Use it to:

--- a/api-reference/endpoint/calling/initiate-individual-call.mdx
+++ b/api-reference/endpoint/calling/initiate-individual-call.mdx
@@ -63,6 +63,56 @@ Add `call_config.call_time.scheduled_at` when the call should be queued for a sp
 
 `call_start_time` and `call_end_time` still act as the allowed calling window in the specified timezone.
 
+## Call deadlines
+
+A queued call is not always dialled straight away: it waits for the allowed calling
+window, for a free concurrency slot, and for any retry backoff. Set a deadline when a
+call stops being worth making after a certain point — an appointment reminder for a slot
+that has passed, or an offer that has expired.
+
+Two ways to express it. Both are optional, and both are honoured on `POST /calling/outbound/individual`
+and its v2 counterpart.
+
+| Field | Meaning | Use when |
+|---|---|---|
+| `call_deadline` | Absolute instant, ISO 8601 | You have a real-world cut-off: `"2026-08-27T18:00:00+05:30"` |
+| `call_validity_hours` | Hours from creation (or from `scheduled_at`) | You have a duration: `2` means "useless after two hours" |
+
+```json
+{
+  "name": "John Doe",
+  "mobile_number": "+919876543210",
+  "agent_id": "your-agent-id",
+  "from_number_id": "your-from-number-id",
+  "call_deadline": "2026-08-27T18:00:00+05:30"
+}
+```
+
+<Warning>
+**Always include a UTC offset in `call_deadline`.** A value without one — `"2026-08-27T18:00:00"` —
+is read as UTC, so a cut-off you meant as 18:00 IST would take effect at 23:30 IST.
+</Warning>
+
+If both fields are set, the **earlier** deadline applies. They do not override one
+another: a call is never dialled past the tightest cut-off you supplied.
+
+### What happens when the deadline passes
+
+The call is **never placed**. When the picker next reaches a call whose deadline has
+passed, it ends it immediately:
+
+| | |
+|---|---|
+| `status` | `cancelled` |
+| `sub_status` | `DEADLINE_PASSED` |
+
+Nothing is dialled, no carrier request is made, and no credits are consumed. The call
+also stops being retried — a deadline that has passed ends the call whether or not it is
+inside the calling window.
+
+Calls with no deadline are unaffected: omit both fields and the call waits as long as it
+needs to.
+
 ## Retry configuration
 
 Use retry settings when a recipient is busy, does not answer, or the provider fails the call.

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1755,6 +1755,19 @@
                     "type": "string",
                     "description": "Optional parent call ID for follow-up or chained-call flows.",
                     "example": "550e8400-e29b-41d4-a716-446655440000"
+},
+                  "call_deadline": {
+                    "type": "string",
+                    "format": "date-time",
+                    "nullable": true,
+                    "description": "Optional absolute cut-off (ISO 8601). The call is not dialled after this instant \u2014 if it is still waiting when the deadline passes it ends as `cancelled` with sub-status `DEADLINE_PASSED`, and is never placed. Include an offset (`+05:30`); a value without one is read as UTC. Use this for a real-world cut-off such as end of shift or an offer expiry, and `call_validity_hours` for a duration from creation. If both are given, the earlier one applies.",
+                    "example": "2026-08-27T18:00:00+05:30"
+                  },
+                  "call_validity_hours": {
+                    "type": "number",
+                    "nullable": true,
+                    "description": "Optional relative cut-off, in hours from when the call is created (or from its scheduled time, if scheduled). Same effect as `call_deadline` but expressed as a duration. If both are given, the earlier one applies.",
+                    "example": 2
                   }
                 },
                 "oneOf": [
@@ -2080,6 +2093,19 @@
                     "nullable": true,
                     "description": "Optional parent call ID for follow-up or chained-call flows.",
                     "example": "550e8400-e29b-41d4-a716-446655440000"
+                  },
+                  "call_deadline": {
+                    "type": "string",
+                    "format": "date-time",
+                    "nullable": true,
+                    "description": "Optional absolute cut-off (ISO 8601). The call is not dialled after this instant \u2014 if it is still waiting when the deadline passes it ends as `cancelled` with sub-status `DEADLINE_PASSED`, and is never placed. Include an offset (`+05:30`); a value without one is read as UTC. Use this for a real-world cut-off such as end of shift or an offer expiry, and `call_validity_hours` for a duration from creation. If both are given, the earlier one applies.",
+                    "example": "2026-08-27T18:00:00+05:30"
+                  },
+                  "call_validity_hours": {
+                    "type": "number",
+                    "nullable": true,
+                    "description": "Optional relative cut-off, in hours from when the call is created (or from its scheduled time, if scheduled). Same effect as `call_deadline` but expressed as a duration. If both are given, the earlier one applies.",
+                    "example": 2
                   }
                 },
                 "description": "At least one of number_pool_id, from_number_id, or from_number is required. **from_number_id and from_number cannot both be set.**"


### PR DESCRIPTION
## Summary
- Documents `call_deadline` (absolute ISO 8601) and `call_validity_hours` (relative) on both `POST /calling/outbound/individual` and its v2 counterpart — **neither was in `openapi.json` before**, so deadline behaviour was entirely undocumented
- New "Call deadlines" section on both pages: when to use which field, that the earlier of the two wins, and what a passed deadline produces (`cancelled` / `DEADLINE_PASSED`, never dialled, no credits)
- Explicit warning on the timezone trap — a value without an offset is read as UTC, so a cut-off meant as 18:00 IST would take effect at 23:30 IST

Backend: Stonkr/new_calling_agent_backend#3331

## Test plan
- [x] `openapi.json` parses; both request schemas verified to carry both fields
- [x] Surgical text insert, not a re-serialize — the file is Prettier-formatted with compact arrays, and a `json.dump` round-trip reformats 515 unrelated lines (first attempt did exactly that; reverted). Diff is 26 insertions, 0 deletions.